### PR TITLE
Implement Navigator Interface Refactoring - Phase 1

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/messages/ConversationListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/messages/ConversationListScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import com.jermey.navplayground.demo.destinations.MessagesPane
 import com.jermey.quo.vadis.annotations.Screen
 import com.jermey.quo.vadis.core.navigation.Navigator
+import com.jermey.quo.vadis.core.navigation.asPaneNavigator
 import org.koin.compose.koinInject
 
 /**
@@ -78,7 +79,8 @@ fun ConversationListScreen(
                     onClick = {
                         // Use navigateToPane to REPLACE the secondary pane content
                         // so each selection swaps the detail view instead of stacking multiple details
-                        navigator.navigateToPane(MessagesPane.ConversationDetail(conversation.id))
+                        navigator.asPaneNavigator()
+                            ?.navigateToPane(MessagesPane.ConversationDetail(conversation.id))
                     }
                 )
                 HorizontalDivider(

--- a/docs/refactoring-plan/navigator-interface-refactoring.md
+++ b/docs/refactoring-plan/navigator-interface-refactoring.md
@@ -1,0 +1,745 @@
+# Navigator Interface Refactoring Plan
+
+## Executive Summary
+
+The `Navigator` interface has grown to expose 25+ members (properties + methods), mixing public API for end-users with internal implementation details used only by the rendering layer. This violates SOLID principles and creates a confusing API surface.
+
+**Goal**: Split Navigator into focused, role-based interfaces following Interface Segregation Principle (ISP).
+
+---
+
+## Table of Contents
+
+1. [Problem Analysis](#problem-analysis)
+2. [SOLID Violations](#solid-violations)
+3. [Current Member Analysis](#current-member-analysis)
+4. [Proposed Architecture](#proposed-architecture)
+5. [Interface Definitions](#interface-definitions)
+6. [Migration Strategy](#migration-strategy)
+7. [Breaking Changes](#breaking-changes)
+8. [Implementation Checklist](#implementation-checklist)
+
+---
+
+## Problem Analysis
+
+### Current Interface Size
+
+The `Navigator` interface currently exposes:
+
+| Category | Count | Members |
+|----------|-------|---------|
+| State observation | 5 | `state`, `transitionState`, `currentDestination`, `previousDestination`, `canNavigateBack`, `currentTransition` |
+| Navigation operations | 6 | `navigate`, `navigateBack`, `navigateAndClearTo`, `navigateAndReplace`, `navigateAndClearAll`, `navigateToPane` |
+| Pane operations | 3 | `isPaneAvailable`, `paneContent`, `navigateBackInPane` |
+| Deep linking | 3 | `handleDeepLink` (2 overloads), `getDeepLinkRegistry` |
+| Internal/Framework | 8 | `resultManager`, `config`, `updateState`, `updateTransitionProgress`, `startPredictiveBack`, `updatePredictiveBack`, `cancelPredictiveBack`, `commitPredictiveBack`, `completeTransition` |
+| Back handling | 1 | `onBack` (via `BackPressHandler`) |
+
+**Total: ~26 members**
+
+### Usage Patterns Observed
+
+From codebase analysis:
+
+1. **End-user screens** (98% of usage):
+   ```kotlin
+   navigator.navigate(DetailDestination("123"))
+   navigator.navigateBack()
+   navigator.currentDestination.collectAsState()
+   navigator.canNavigateBack.collectAsState()
+   ```
+
+2. **Advanced users** (e.g., `StateDrivenContainer`):
+   ```kotlin
+   navigator.updateState(clearedState)
+   navigator.state.value  // direct tree manipulation
+   ```
+
+3. **Framework internals** (NavigationHost, renderers):
+   ```kotlin
+   navigator.config  // only NavigationHost
+   navigator.resultManager  // only extension functions
+   navigator.updateTransitionProgress(0.5f)
+   navigator.startPredictiveBack()
+   navigator.updatePredictiveBack(progress, x, y)
+   navigator.cancelPredictiveBack()
+   navigator.commitPredictiveBack()
+   navigator.completeTransition()
+   navigator.transitionState.collect { ... }
+   ```
+
+4. **Deep link registration**:
+   ```kotlin
+   navigator.getDeepLinkRegistry().register("promo/{code}") { params -> }
+   navigator.handleDeepLink(uri)
+   ```
+
+---
+
+## SOLID Violations
+
+### 1. Interface Segregation Principle (ISP) ❌
+
+**Violation**: Clients are forced to depend on methods they don't use.
+
+- Screen composables only need `navigate()`, `navigateBack()`, state observation
+- They're exposed to `updateTransitionProgress()`, `commitPredictiveBack()`, `resultManager`, etc.
+
+### 2. Single Responsibility Principle (SRP) ❌
+
+**Violation**: Navigator has multiple responsibilities:
+- Navigation command execution
+- State observation
+- Transition animation control
+- Predictive back gesture handling
+- Result management
+- Deep link handling
+- Configuration access
+
+### 3. Open/Closed Principle (OCP) ⚠️
+
+**Partial violation**: Adding new functionality requires modifying the interface.
+
+With focused interfaces, new capabilities could be added via new interfaces without modifying existing ones.
+
+### 4. Dependency Inversion Principle (DIP) ⚠️
+
+**Partial violation**: High-level screens depend on low-level implementation details.
+
+Screens should depend on a navigation abstraction, not on transition management details.
+
+---
+
+## Current Member Analysis
+
+### ✅ Public API (Keep in main Navigator)
+
+| Member | Usage | Justification |
+|--------|-------|---------------|
+| `state` | End-users, framework | Core observable state |
+| `currentDestination` | End-users | Convenience - most common observation |
+| `previousDestination` | End-users | Convenience - enable/disable back button styling |
+| `canNavigateBack` | End-users | Convenience - enable/disable back button |
+| `navigate()` | End-users | Core navigation operation |
+| `navigateBack()` | End-users | Core navigation operation |
+| `navigateAndClearTo()` | End-users | Common pattern (auth flows) |
+| `navigateAndReplace()` | End-users | Common pattern (onboarding) |
+| `navigateAndClearAll()` | End-users | Common pattern (logout) |
+| `handleDeepLink(uri)` | End-users | Deep link handling |
+| `getDeepLinkRegistry()` | End-users | Runtime deep link registration |
+| `updateState()` | Advanced users | Direct tree manipulation for state-driven patterns |
+| `config` | NavigationHost, advanced users | Access to registries |
+
+### ⚠️ Pane API (Separate interface)
+
+| Member | Usage | Justification |
+|--------|-------|---------------|
+| `navigateToPane()` | Pane-specific screens | Adaptive layout navigation |
+| `isPaneAvailable()` | Pane-specific screens | Query pane configuration |
+| `paneContent()` | Pane-specific screens | Query pane content |
+| `navigateBackInPane()` | Pane-specific screens | Pane-specific back |
+
+### 🔒 Internal API (Hide from public interface)
+
+| Member | Usage | Justification |
+|--------|-------|---------------|
+| `resultManager` | Extension functions only | Implementation detail |
+| `transitionState` | Framework only | Animation internal |
+| `currentTransition` | Framework only | Animation internal |
+| `updateTransitionProgress()` | Framework only | Animation internal |
+| `startPredictiveBack()` | Framework only | Gesture internal |
+| `updatePredictiveBack()` | Framework only | Gesture internal |
+| `cancelPredictiveBack()` | Framework only | Gesture internal |
+| `commitPredictiveBack()` | Framework only | Gesture internal |
+| `completeTransition()` | Framework only | Animation internal |
+
+---
+
+## Proposed Architecture
+
+### Interface Hierarchy
+
+```
+                          ┌─────────────────────────┐
+                          │       Navigator         │  ◄─── Main public API
+                          │ (Interface)             │       for end-users
+                          ├─────────────────────────┤
+                          │ • state                 │
+                          │ • currentDestination    │
+                          │ • previousDestination   │
+                          │ • canNavigateBack       │
+                          │ • navigate()            │
+                          │ • navigateBack()        │
+                          │ • navigateAndClearTo()  │
+                          │ • navigateAndReplace()  │
+                          │ • navigateAndClearAll() │
+                          │ • handleDeepLink()      │
+                          │ • deepLinkRegistry      │
+                          │ • updateState()         │
+                          │ • config                │
+                          └───────────┬─────────────┘
+                                      │
+                    ┌─────────────────┴─────────────────┐
+                    │                                   │
+                    ▼                                   ▼
+          ┌───────────────────┐           ┌───────────────────────┐
+          │ PaneNavigator     │           │  internal interface   │
+          │ (Interface)       │           │  TransitionController │
+          ├───────────────────┤           ├───────────────────────┤
+          │ • navigateToPane()│           │ • transitionState     │
+          │ • isPaneAvailable │           │ • currentTransition   │
+          │ • paneContent()   │           │ • updateProgress()    │
+          │ • backInPane()    │           │ • startPredictive()   │
+          └───────────────────┘           │ • updatePredictive()  │
+                                          │ • cancelPredictive()  │
+                                          │ • commitPredictive()  │
+                                          │ • complete()          │
+                                          └───────────────────────┘
+```
+
+### Implementation Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           TreeNavigator                                      │
+│                                                                             │
+│  implements Navigator, PaneNavigator, TransitionController                   │
+│                                                                             │
+│  ┌─────────────────────────────────────────────────────────────────────────┐│
+│  │                         Internal State                                  ││
+│  │  • _state: MutableStateFlow<NavNode>                                   ││
+│  │  • _transitionState: MutableStateFlow<TransitionState>                 ││
+│  │  • _resultManager: NavigationResultManager                             ││
+│  │  • _config: NavigationConfig                                           ││
+│  └─────────────────────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Interface Definitions
+
+### 1. Navigator (Slim Public API)
+
+```kotlin
+/**
+ * Central navigation controller for end-user navigation operations.
+ * 
+ * This is the primary interface for screen composables to perform navigation.
+ * For pane-specific operations in adaptive layouts, use [PaneNavigator].
+ * 
+ * @see PaneNavigator
+ */
+@Stable
+interface Navigator : BackPressHandler {
+    
+    // =========================================================================
+    // STATE OBSERVATION
+    // =========================================================================
+    
+    /**
+     * The current navigation state as an immutable tree.
+     * This is the single source of truth for all navigation state.
+     */
+    val state: StateFlow<NavNode>
+    
+    /**
+     * The currently active destination (deepest active ScreenNode).
+     */
+    val currentDestination: StateFlow<NavDestination?>
+    
+    /**
+     * The previous destination before the current one.
+     */
+    val previousDestination: StateFlow<NavDestination?>
+    
+    /**
+     * Whether back navigation is possible from the current state.
+     */
+    val canNavigateBack: StateFlow<Boolean>
+    
+    // =========================================================================
+    // CONFIGURATION
+    // =========================================================================
+    
+    /**
+     * The navigation configuration providing access to registries.
+     * 
+     * NavigationHost uses this to resolve screen content, transitions,
+     * and container wrappers. Also useful for advanced state-driven patterns.
+     */
+    val config: NavigationConfig
+    
+    // =========================================================================
+    // NAVIGATION OPERATIONS
+    // =========================================================================
+    
+    /**
+     * Navigate to a destination with optional transition.
+     */
+    fun navigate(
+        destination: NavDestination,
+        transition: NavigationTransition? = null
+    )
+    
+    /**
+     * Navigate back in the active stack.
+     * @return true if navigation was successful, false if at root
+     */
+    fun navigateBack(): Boolean
+    
+    /**
+     * Navigate to a destination and clear the backstack up to a certain point.
+     */
+    fun navigateAndClearTo(
+        destination: NavDestination,
+        clearRoute: String? = null,
+        inclusive: Boolean = false
+    )
+    
+    /**
+     * Navigate to a destination and replace the current one.
+     */
+    fun navigateAndReplace(
+        destination: NavDestination,
+        transition: NavigationTransition? = null
+    )
+    
+    /**
+     * Navigate to a destination and clear the entire active stack.
+     */
+    fun navigateAndClearAll(destination: NavDestination)
+    
+    // =========================================================================
+    // STATE MANIPULATION
+    // =========================================================================
+    
+    /**
+     * Update the navigation state directly.
+     * 
+     * This is useful for state-driven navigation patterns and state restoration.
+     * Prefer higher-level navigation methods for typical use cases.
+     */
+    fun updateState(newState: NavNode, transition: NavigationTransition? = null)
+    
+    // =========================================================================
+    // DEEP LINKING
+    // =========================================================================
+    
+    /**
+     * Handle a deep link URI string.
+     * @return true if navigation occurred, false if no match
+     */
+    fun handleDeepLink(uri: String): Boolean
+    
+    /**
+     * Handle deep link navigation.
+     */
+    fun handleDeepLink(deepLink: DeepLink)
+    
+    /**
+     * Get the deep link registry for pattern registration.
+     */
+    val deepLinkRegistry: DeepLinkRegistry
+}
+```
+
+**Lines of code**: ~95 (includes `updateState` and `config`)
+
+### 2. PaneNavigator (Adaptive Layout Extension)
+
+```kotlin
+/**
+ * Extension interface for pane-specific navigation operations.
+ * 
+ * Use this interface when working with adaptive multi-pane layouts.
+ * Obtain via extension function or cast when needed.
+ * 
+ * ```kotlin
+ * val paneNavigator = navigator.asPaneNavigator()
+ * paneNavigator?.navigateToPane(DetailDestination(id), PaneRole.Supporting)
+ * ```
+ */
+@Stable
+interface PaneNavigator : Navigator {
+    
+    /**
+     * Navigate to a destination in a specific pane.
+     */
+    fun navigateToPane(
+        destination: NavDestination,
+        role: PaneRole = PaneRole.Supporting
+    )
+    
+    /**
+     * Check if a pane role is available in the current state.
+     */
+    fun isPaneAvailable(role: PaneRole): Boolean
+    
+    /**
+     * Get the current content of a specific pane.
+     */
+    fun paneContent(role: PaneRole): NavNode?
+    
+    /**
+     * Navigate back within a specific pane.
+     */
+    fun navigateBackInPane(role: PaneRole): Boolean
+}
+
+/**
+ * Safely cast Navigator to PaneNavigator if supported.
+ */
+fun Navigator.asPaneNavigator(): PaneNavigator? = this as? PaneNavigator
+```
+
+### 3. TransitionController (Internal Only)
+
+```kotlin
+/**
+ * Internal interface for transition and animation control.
+ * 
+ * This interface is NOT part of the public API and should only be used
+ * by the NavigationHost and rendering layer.
+ * 
+ * @suppress
+ */
+@InternalQuoVadisApi
+internal interface TransitionController {
+    
+    /**
+     * The current transition state for animations.
+     */
+    val transitionState: StateFlow<TransitionState>
+    
+    /**
+     * Current transition animation (null if idle).
+     */
+    val currentTransition: StateFlow<NavigationTransition?>
+    
+    /**
+     * Update transition progress during animations.
+     */
+    fun updateTransitionProgress(progress: Float)
+    
+    /**
+     * Start a predictive back gesture.
+     */
+    fun startPredictiveBack()
+    
+    /**
+     * Update predictive back gesture progress.
+     */
+    fun updatePredictiveBack(progress: Float, touchX: Float, touchY: Float)
+    
+    /**
+     * Cancel the predictive back gesture.
+     */
+    fun cancelPredictiveBack()
+    
+    /**
+     * Commit the predictive back gesture.
+     */
+    fun commitPredictiveBack()
+    
+    /**
+     * Complete the current transition animation.
+     */
+    fun completeTransition()
+}
+```
+
+### 4. ResultManager Access (Private Extension)
+
+```kotlin
+// Keep resultManager internal, only accessible via extension functions
+
+// Internal accessor in core module
+internal val Navigator.resultManager: NavigationResultManager
+    get() = (this as TreeNavigator).resultManager
+
+// Or use an internal interface
+@InternalQuoVadisApi
+internal interface ResultCapable {
+    val resultManager: NavigationResultManager
+}
+```
+
+---
+
+## Migration Strategy
+
+### Phase 1: Create New Interfaces (Non-Breaking)
+
+1. **Create interface files**:
+   - `Navigator.kt` - Public API (with `updateState` and `config`)
+   - `PaneNavigator.kt` - Pane extension
+   - `TransitionController.kt` - Internal API
+
+2. **Update TreeNavigator**:
+   ```kotlin
+   class TreeNavigator(/* ... */) : 
+       Navigator, 
+       PaneNavigator, 
+       TransitionController {
+       // Implementation unchanged
+   }
+   ```
+
+3. **Update FakeNavigator** for tests similarly
+
+### Phase 2: Add Deprecations
+
+Add `@Deprecated` annotations to members moving to new interfaces:
+
+```kotlin
+interface Navigator {
+    @Deprecated(
+        "Use navigator.asPaneNavigator()?.navigateToPane() instead",
+        ReplaceWith("asPaneNavigator()?.navigateToPane(destination, role)")
+    )
+    fun navigateToPane(destination: NavDestination, role: PaneRole)
+    
+    @Deprecated(
+        "Moved to TransitionController (internal API). " +
+        "If you need transition state, use currentDestination instead.",
+        level = DeprecationLevel.WARNING
+    )
+    val transitionState: StateFlow<TransitionState>
+}
+```
+
+### Phase 3: Update Internal Usages
+
+1. **NavigationHost**: Cast to `TransitionController`
+   ```kotlin
+   @Composable
+   fun NavigationHost(navigator: Navigator, ...) {
+       val transitionController = navigator as? TransitionController
+           ?: error("Navigator must implement TransitionController")
+       
+       // Use transitionController for animation APIs
+   }
+   ```
+
+2. **Extension functions**: Use internal accessor
+   ```kotlin
+   suspend fun <R : Any, D> Navigator.navigateForResult(destination: D): R? 
+       where D : NavDestination, D : ReturnsResult<R> {
+       val manager = (this as? ResultCapable)?.resultManager
+           ?: error("Navigator must support results")
+       // ...
+   }
+   ```
+
+### Phase 4: Documentation Updates
+
+1. Update `ARCHITECTURE.md` with new interface hierarchy
+2. Update API docs to reference correct interfaces
+3. Add migration guide section
+
+### Phase 5: Cleanup (Major Version)
+
+In next major version:
+1. Remove deprecated methods from `Navigator` interface
+2. Make `TransitionController` `internal`
+3. Hide `resultManager` completely
+
+---
+
+## Breaking Changes
+
+### Breaking Changes in Phase 5 (Major Version)
+
+| Change | Impact | Migration |
+|--------|--------|-----------|
+| `navigateToPane()` removed from `Navigator` | Compile error | Use `navigator.asPaneNavigator()?.navigateToPane()` |
+| `isPaneAvailable()` removed from `Navigator` | Compile error | Use `navigator.asPaneNavigator()?.isPaneAvailable()` |
+| `paneContent()` removed from `Navigator` | Compile error | Use `navigator.asPaneNavigator()?.paneContent()` |
+| `navigateBackInPane()` removed from `Navigator` | Compile error | Use `navigator.asPaneNavigator()?.navigateBackInPane()` |
+| `transitionState` removed from `Navigator` | Compile error | Framework only - no user migration needed |
+| `resultManager` hidden | Compile error | Use `navigateForResult()` extension |
+| Predictive back methods removed | Compile error | Framework only - no user migration needed |
+
+### Non-Breaking in All Phases
+
+- `state`, `currentDestination`, `previousDestination`, `canNavigateBack` stay
+- `navigate()`, `navigateBack()`, `navigateAnd*()` stay
+- `handleDeepLink()`, `deepLinkRegistry` stay
+- `updateState()`, `config` stay in main Navigator
+- Extension functions continue to work
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Interface Creation
+- [ ] Create `PaneNavigator.kt` interface
+- [ ] Create `TransitionController.kt` internal interface
+- [ ] Create `ResultCapable.kt` internal interface
+- [ ] Update `Navigator.kt` (slim down, keep `updateState` and `config`)
+- [ ] Update `TreeNavigator` to implement all interfaces
+- [ ] Update `FakeNavigator` to implement all interfaces
+- [ ] Add extension function `asPaneNavigator()`
+- [ ] Update internal `resultManager` accessor
+
+### Phase 2: Deprecations
+- [ ] Add `@Deprecated` to pane methods in `Navigator`
+- [ ] Add `@Deprecated` to `transitionState` in `Navigator`
+- [ ] Add `@Deprecated` to `currentTransition` in `Navigator`
+- [ ] Add `@Deprecated` to predictive back methods in `Navigator`
+- [ ] Add `@Deprecated` to `updateTransitionProgress()` in `Navigator`
+- [ ] Add `@Deprecated` to `completeTransition()` in `Navigator`
+- [ ] Add `@Deprecated` to `resultManager` in `Navigator`
+
+### Phase 3: Internal Updates
+- [ ] Update `NavigationHost.kt` to use `TransitionController`
+- [ ] Update `NavTreeRenderer.kt` to use `TransitionController`
+- [ ] Update `StackRenderer.kt` to use `TransitionController`
+- [ ] Update `PaneRenderer.kt` to use `TransitionController`
+- [ ] Update `TabRenderer.kt` to use `TransitionController`
+- [ ] Update `NavigatorResultExtensions.kt` to use internal accessor
+- [ ] Update wrapper scopes (`TabsContainerScope`, `PaneContainerScope`)
+
+### Phase 4: Documentation
+- [ ] Update `ARCHITECTURE.md`
+- [ ] Update KDoc in all interface files
+- [ ] Add migration guide
+- [ ] Update website documentation
+
+### Phase 5: Cleanup (Major Version)
+- [ ] Remove deprecated methods from `Navigator`
+- [ ] Make `TransitionController` visibility `internal`
+- [ ] Remove `resultManager` from public API
+- [ ] Update version to next major
+
+---
+
+## Design Principles Applied
+
+### SOLID
+
+| Principle | Application |
+|-----------|-------------|
+| **SRP** | Each interface has one responsibility |
+| **OCP** | New features via new interfaces, not modifications |
+| **LSP** | All implementations are substitutable |
+| **ISP** | Clients only depend on methods they use |
+| **DIP** | Screens depend on abstractions, not implementations |
+
+### KISS
+
+- Main `Navigator` interface is simple and focused
+- Extension interfaces opt-in only when needed
+- No complex inheritance hierarchies
+
+### Kotlin Idioms
+
+- Extension functions for safe casting (`asPaneNavigator()`)
+- `@InternalQuoVadisApi` annotation for internal APIs
+- Functional approach preserved (pure functions in `TreeMutator`)
+- `StateFlow` for reactive state observation
+
+---
+
+## Appendix: Full Interface Comparison
+
+### Before (Current)
+
+```kotlin
+interface Navigator : BackPressHandler {
+    // 6 state properties
+    val state: StateFlow<NavNode>
+    val transitionState: StateFlow<TransitionState>
+    val currentDestination: StateFlow<NavDestination?>
+    val previousDestination: StateFlow<NavDestination?>
+    val currentTransition: StateFlow<NavigationTransition?>
+    val canNavigateBack: StateFlow<Boolean>
+    
+    // 2 manager properties
+    val resultManager: NavigationResultManager
+    val config: NavigationConfig
+    
+    // 6 navigation methods
+    fun navigate(...)
+    fun navigateBack(): Boolean
+    fun navigateAndClearTo(...)
+    fun navigateAndReplace(...)
+    fun navigateAndClearAll(...)
+    fun navigateToPane(...)
+    
+    // 4 pane methods
+    fun isPaneAvailable(...): Boolean
+    fun paneContent(...): NavNode?
+    fun navigateBackInPane(...): Boolean
+    
+    // 3 deep link methods
+    fun handleDeepLink(uri: String): Boolean
+    fun handleDeepLink(deepLink: DeepLink)
+    fun getDeepLinkRegistry(): DeepLinkRegistry
+    
+    // 1 state manipulation
+    fun updateState(...)
+    
+    // 6 transition methods
+    fun updateTransitionProgress(...)
+    fun startPredictiveBack()
+    fun updatePredictiveBack(...)
+    fun cancelPredictiveBack()
+    fun commitPredictiveBack()
+    fun completeTransition()
+}
+// Total: ~26 members
+```
+
+### After (Proposed)
+
+```kotlin
+// Main API - 15 members (42% reduction)
+interface Navigator : BackPressHandler {
+    val state: StateFlow<NavNode>
+    val currentDestination: StateFlow<NavDestination?>
+    val previousDestination: StateFlow<NavDestination?>
+    val canNavigateBack: StateFlow<Boolean>
+    val config: NavigationConfig
+    
+    fun navigate(...)
+    fun navigateBack(): Boolean
+    fun navigateAndClearTo(...)
+    fun navigateAndReplace(...)
+    fun navigateAndClearAll(...)
+    fun updateState(...)
+    
+    fun handleDeepLink(uri: String): Boolean
+    fun handleDeepLink(deepLink: DeepLink)
+    val deepLinkRegistry: DeepLinkRegistry
+}
+
+// Pane extension - 4 members
+interface PaneNavigator : Navigator {
+    fun navigateToPane(...)
+    fun isPaneAvailable(...): Boolean
+    fun paneContent(...): NavNode?
+    fun navigateBackInPane(...): Boolean
+}
+
+// Internal - 8 members
+internal interface TransitionController {
+    val transitionState: StateFlow<TransitionState>
+    val currentTransition: StateFlow<NavigationTransition?>
+    fun updateTransitionProgress(...)
+    fun startPredictiveBack()
+    fun updatePredictiveBack(...)
+    fun cancelPredictiveBack()
+    fun commitPredictiveBack()
+    fun completeTransition()
+}
+
+// Internal - 1 member
+internal interface ResultCapable {
+    val resultManager: NavigationResultManager
+}
+```
+
+**Result**: Main public API reduced from 26 to 15 members (42% reduction), with clear separation of internal/framework APIs from public APIs. Pane-specific functionality moved to optional extension interface.

--- a/docs/refactoring-plan/tree-mutator-refactoring.md
+++ b/docs/refactoring-plan/tree-mutator-refactoring.md
@@ -1,0 +1,758 @@
+# TreeMutator Refactoring Plan
+
+## Overview
+
+The `TreeMutator` object (~1,770 lines, ~40+ functions) has grown beyond maintainable limits and violates several SOLID principles. This document outlines a refactoring strategy to decompose it into smaller, focused components while preserving the functional/immutable nature of tree operations.
+
+## Current Issues
+
+### 1. Size & Complexity Violations
+| Metric | Current | Detekt Limit |
+|--------|---------|--------------|
+| Lines of Code | ~1,770 | 600 |
+| Functions | ~40+ | 11 |
+| Responsibilities | 6+ distinct areas | 1 (SRP) |
+
+### 2. SOLID Violations
+
+| Principle | Violation |
+|-----------|-----------|
+| **S**ingle Responsibility | Handles push, pop, tab, pane, utility, and back operations |
+| **O**pen/Closed | Adding new node types requires modifying TreeMutator |
+| **I**nterface Segregation | All operations bundled in one object |
+| **D**ependency Inversion | Direct coupling between operation categories |
+
+### 3. Code Organization Issues
+- Nested sealed classes (`PopResult`, `BackResult`, `PushStrategy`) are internal details exposed at module level
+- Configuration enums mixed with operations
+- Utility functions (`replaceNode`, `removeNode`) used by all categories but not separated
+- Similar patterns repeated across different node types (StackNode, TabNode, PaneNode)
+
+---
+
+## Refactoring Goals
+
+1. **Single Responsibility**: Each class handles one category of operations
+2. **Extensibility**: Easy to add new node types without modifying existing code
+3. **Testability**: Smaller units are easier to test in isolation
+4. **Discoverability**: Clear naming and organization for API consumers
+5. **Kotlin Idioms**: Leverage extension functions, sealed hierarchies, and DSLs
+
+---
+
+## Proposed Architecture
+
+### Package Structure
+
+```
+com.jermey.quo.vadis.core.navigation.tree/
+├── TreeMutator.kt              # Façade (delegates to specialized mutators)
+├── result/                     # Result types
+│   ├── PopResult.kt
+│   ├── BackResult.kt
+│   └── PushStrategy.kt
+├── config/                     # Configuration types
+│   └── PopBehavior.kt
+├── operations/                 # Specialized operation classes
+│   ├── TreeNodeOperations.kt   # Core tree manipulation (replaceNode, removeNode)
+│   ├── PushOperations.kt       # All push-related operations
+│   ├── PopOperations.kt        # All pop-related operations
+│   ├── TabOperations.kt        # Tab switching operations
+│   ├── PaneOperations.kt       # Pane navigation operations
+│   └── BackOperations.kt       # Tree-aware back handling
+└── util/                       # Utilities
+    └── KeyGenerator.kt         # Key generation abstraction
+```
+
+### Component Responsibilities
+
+#### 1. `TreeNodeOperations.kt` (~100 lines)
+**Purpose**: Core tree manipulation utilities used by all other operations.
+
+```kotlin
+/**
+ * Core tree manipulation utilities.
+ * 
+ * Provides foundational operations for modifying the NavNode tree:
+ * - Node replacement (structural sharing)
+ * - Node removal
+ * - Node lookup helpers
+ */
+object TreeNodeOperations {
+    fun replaceNode(root: NavNode, targetKey: String, newNode: NavNode): NavNode
+    fun removeNode(root: NavNode, targetKey: String): NavNode?
+}
+```
+
+**Functions to extract**:
+- `replaceNode()` 
+- `removeNode()`
+
+---
+
+#### 2. `PushOperations.kt` (~300 lines)
+**Purpose**: All navigation push operations.
+
+```kotlin
+/**
+ * Push operations for the navigation tree.
+ * 
+ * Handles all forward navigation:
+ * - Simple push to active stack
+ * - Push to specific stack by key
+ * - Scope-aware push with tab switching
+ * - Pane role routing
+ * - Multi-destination push
+ * - Clear and push patterns
+ */
+object PushOperations {
+    // Simple push operations
+    fun push(root: NavNode, destination: NavDestination, generateKey: () -> String): NavNode
+    fun pushToStack(root: NavNode, stackKey: String, destination: NavDestination, generateKey: () -> String): NavNode
+    
+    // Scope-aware operations
+    fun push(
+        root: NavNode,
+        destination: NavDestination,
+        scopeRegistry: ScopeRegistry,
+        paneRoleRegistry: PaneRoleRegistry,
+        generateKey: () -> String
+    ): NavNode
+    
+    // Batch operations
+    fun pushAll(root: NavNode, destinations: List<NavDestination>, generateKey: () -> String): NavNode
+    
+    // Clear patterns
+    fun clearAndPush(root: NavNode, destination: NavDestination, generateKey: () -> String): NavNode
+    fun clearStackAndPush(root: NavNode, stackKey: String, destination: NavDestination, generateKey: () -> String): NavNode
+    fun replaceCurrent(root: NavNode, destination: NavDestination, generateKey: () -> String): NavNode
+}
+
+// Internal helpers (private)
+private fun determinePushStrategy(...): PushStrategy
+private fun findTabWithDestination(...): Int?
+private fun pushToActiveStack(...): NavNode
+private fun pushOutOfScope(...): NavNode
+private fun pushToPaneStack(...): NavNode
+```
+
+**Functions to extract**:
+- `push()` (simple)
+- `pushToStack()`
+- `push()` (scope-aware)
+- `determinePushStrategy()` (private)
+- `findTabWithDestination()` (private)
+- `pushToActiveStack()` (private)
+- `pushOutOfScope()` (private)
+- `pushToPaneStack()` (private)
+- `pushAll()`
+- `clearAndPush()`
+- `clearStackAndPush()`
+- `replaceCurrent()`
+
+---
+
+#### 3. `PopOperations.kt` (~200 lines)
+**Purpose**: All navigation pop operations.
+
+```kotlin
+/**
+ * Pop operations for the navigation tree.
+ * 
+ * Handles all backward navigation from stacks:
+ * - Simple pop from active stack
+ * - Pop to predicate/route/destination type
+ * - Configurable empty stack behavior
+ */
+object PopOperations {
+    fun pop(root: NavNode, behavior: PopBehavior = PopBehavior.PRESERVE_EMPTY): NavNode?
+    fun popTo(root: NavNode, inclusive: Boolean = false, predicate: (NavNode) -> Boolean): NavNode
+    fun popToRoute(root: NavNode, route: String, inclusive: Boolean = false): NavNode
+    inline fun <reified D : NavDestination> popToDestination(root: NavNode, inclusive: Boolean = false): NavNode
+}
+
+// Internal helpers
+private fun handleEmptyStackPop(root: NavNode, emptyStack: StackNode, behavior: PopBehavior): NavNode?
+```
+
+**Functions to extract**:
+- `pop()`
+- `popTo()`
+- `popToRoute()`
+- `popToDestination()`
+- `handleEmptyStackPop()` (private)
+
+---
+
+#### 4. `TabOperations.kt` (~80 lines)
+**Purpose**: Tab switching operations.
+
+```kotlin
+/**
+ * Tab switching operations for TabNode.
+ * 
+ * Handles tab navigation:
+ * - Switch to tab by index and key
+ * - Switch active tab in path
+ */
+object TabOperations {
+    fun switchTab(root: NavNode, tabNodeKey: String, newIndex: Int): NavNode
+    fun switchActiveTab(root: NavNode, newIndex: Int): NavNode
+}
+```
+
+**Functions to extract**:
+- `switchTab()`
+- `switchActiveTab()`
+
+---
+
+#### 5. `PaneOperations.kt` (~350 lines)
+**Purpose**: All pane-related navigation operations.
+
+```kotlin
+/**
+ * Pane navigation operations for PaneNode.
+ * 
+ * Handles adaptive layout navigation:
+ * - Navigate to specific pane
+ * - Switch active pane
+ * - Pop from pane with behavior awareness
+ * - Pane configuration management
+ */
+object PaneOperations {
+    // Navigation
+    fun navigateToPane(
+        root: NavNode,
+        nodeKey: String,
+        role: PaneRole,
+        destination: NavDestination,
+        switchFocus: Boolean = true,
+        generateKey: () -> String
+    ): NavNode
+    
+    // Pane management
+    fun switchActivePane(root: NavNode, nodeKey: String, role: PaneRole): NavNode
+    fun popPane(root: NavNode, nodeKey: String, role: PaneRole): NavNode?
+    
+    // Behavior-aware pop
+    fun popWithPaneBehavior(root: NavNode): PopResult
+    fun popPaneAdaptive(root: NavNode, isCompact: Boolean): PopResult
+    
+    // Configuration
+    fun setPaneConfiguration(root: NavNode, nodeKey: String, role: PaneRole, config: PaneConfiguration): NavNode
+    fun removePaneConfiguration(root: NavNode, nodeKey: String, role: PaneRole): NavNode
+}
+
+// Internal helpers
+private fun popFromActivePane(root: NavNode, paneNode: PaneNode): PopResult
+private fun clearPaneStack(root: NavNode, paneNodeKey: String, role: PaneRole): NavNode
+```
+
+**Functions to extract**:
+- `navigateToPane()`
+- `switchActivePane()`
+- `popPane()`
+- `popWithPaneBehavior()`
+- `popPaneAdaptive()`
+- `popFromActivePane()` (private)
+- `clearPaneStack()` (private)
+- `setPaneConfiguration()`
+- `removePaneConfiguration()`
+
+---
+
+#### 6. `BackOperations.kt` (~300 lines)
+**Purpose**: Tree-aware back navigation handling.
+
+```kotlin
+/**
+ * Tree-aware back navigation operations.
+ * 
+ * Handles intelligent back navigation:
+ * - Tab-aware back with cascade behavior
+ * - Pane-aware back with window size consideration
+ * - Back capability checking
+ */
+object BackOperations {
+    fun popWithTabBehavior(root: NavNode, isCompact: Boolean = true): BackResult
+    fun canGoBack(root: NavNode): Boolean
+    fun canHandleBackNavigation(root: NavNode): Boolean
+    fun currentDestination(root: NavNode): NavDestination?
+}
+
+// Internal helpers (complex back handling logic)
+private fun handleRootStackBack(root: NavNode, activeStack: StackNode): BackResult
+private fun handleTabBack(root: NavNode, tabNode: TabNode): BackResult
+private fun handleNestedStackBack(root: NavNode, parentStack: StackNode, childStack: StackNode): BackResult
+private fun handlePaneBack(root: NavNode, paneNode: PaneNode, isCompact: Boolean): BackResult
+private fun popEntirePaneNode(root: NavNode, paneNode: PaneNode): BackResult
+```
+
+**Functions to extract**:
+- `popWithTabBehavior()`
+- `canGoBack()`
+- `canHandleBackNavigation()`
+- `currentDestination()`
+- `handleRootStackBack()` (private)
+- `handleTabBack()` (private)
+- `handleNestedStackBack()` (private)
+- `handlePaneBack()` (private)
+- `popEntirePaneNode()` (private)
+
+---
+
+#### 7. Result Types (Separate Files)
+
+**`result/PopResult.kt`**:
+```kotlin
+/**
+ * Result of a pop operation that respects PaneBackBehavior.
+ */
+sealed class PopResult {
+    data class Popped(val newState: NavNode) : PopResult()
+    data class PaneEmpty(val paneRole: PaneRole) : PopResult()
+    data object CannotPop : PopResult()
+    data object RequiresScaffoldChange : PopResult()
+}
+```
+
+**`result/BackResult.kt`**:
+```kotlin
+/**
+ * Result of a tree-aware back operation.
+ */
+sealed class BackResult {
+    data class Handled(val newState: NavNode) : BackResult()
+    data object DelegateToSystem : BackResult()
+    data object CannotHandle : BackResult()
+}
+```
+
+**`result/PushStrategy.kt`** (internal):
+```kotlin
+/**
+ * Internal strategy for push operations with tab/pane awareness.
+ */
+internal sealed class PushStrategy {
+    data class PushToStack(val targetStack: StackNode) : PushStrategy()
+    data class SwitchToTab(val tabNode: TabNode, val tabIndex: Int) : PushStrategy()
+    data class PushToPaneStack(val paneNode: PaneNode, val role: PaneRole) : PushStrategy()
+    data class PushOutOfScope(val parentStack: StackNode) : PushStrategy()
+}
+```
+
+---
+
+#### 8. Configuration Types
+
+**`config/PopBehavior.kt`**:
+```kotlin
+/**
+ * Configures behavior when a StackNode becomes empty after pop.
+ */
+enum class PopBehavior {
+    /** Remove the empty stack from parent (cascading pop). */
+    CASCADE,
+    
+    /** Preserve the empty stack in place. */
+    PRESERVE_EMPTY
+}
+```
+
+---
+
+#### 9. Key Generator Abstraction
+
+**`util/KeyGenerator.kt`**:
+```kotlin
+/**
+ * Abstraction for generating unique node keys.
+ */
+fun interface KeyGenerator {
+    fun generate(): String
+    
+    companion object {
+        @OptIn(ExperimentalUuidApi::class)
+        val Default: KeyGenerator = KeyGenerator { Uuid.random().toString().take(8) }
+    }
+}
+```
+
+---
+
+#### 10. Façade Pattern - `TreeMutator.kt` (~150 lines)
+
+The original `TreeMutator` becomes a façade that delegates to specialized operations:
+
+```kotlin
+/**
+ * Pure functional operations for manipulating the NavNode tree.
+ *
+ * This object provides a unified API for all tree mutations. Internally,
+ * operations are delegated to specialized handlers:
+ * - [PushOperations] - forward navigation
+ * - [PopOperations] - backward navigation
+ * - [TabOperations] - tab switching
+ * - [PaneOperations] - pane navigation
+ * - [BackOperations] - tree-aware back handling
+ *
+ * All operations are immutable - they return new tree instances rather than
+ * modifying existing ones.
+ *
+ * @see PushOperations
+ * @see PopOperations
+ * @see TabOperations
+ * @see PaneOperations
+ * @see BackOperations
+ */
+object TreeMutator {
+    
+    // Re-export types for backward compatibility
+    @Deprecated("Use PopBehavior directly", ReplaceWith("PopBehavior"))
+    typealias PopBehavior = com.jermey.quo.vadis.core.navigation.tree.config.PopBehavior
+    
+    // =========================================================================
+    // PUSH OPERATIONS (delegate to PushOperations)
+    // =========================================================================
+    
+    fun push(
+        root: NavNode,
+        destination: NavDestination,
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.push(root, destination, generateKey)
+    
+    fun pushToStack(
+        root: NavNode,
+        stackKey: String,
+        destination: NavDestination,
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.pushToStack(root, stackKey, destination, generateKey)
+    
+    fun push(
+        root: NavNode,
+        destination: NavDestination,
+        scopeRegistry: ScopeRegistry,
+        paneRoleRegistry: PaneRoleRegistry = PaneRoleRegistry.Empty,
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.push(root, destination, scopeRegistry, paneRoleRegistry, generateKey)
+    
+    fun pushAll(
+        root: NavNode,
+        destinations: List<NavDestination>,
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.pushAll(root, destinations, generateKey)
+    
+    fun clearAndPush(
+        root: NavNode,
+        destination: NavDestination,
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.clearAndPush(root, destination, generateKey)
+    
+    fun clearStackAndPush(
+        root: NavNode,
+        stackKey: String,
+        destination: NavDestination,
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.clearStackAndPush(root, stackKey, destination, generateKey)
+    
+    fun replaceCurrent(
+        root: NavNode,
+        destination: NavDestination,
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.replaceCurrent(root, destination, generateKey)
+    
+    // =========================================================================
+    // POP OPERATIONS (delegate to PopOperations)
+    // =========================================================================
+    
+    fun pop(
+        root: NavNode,
+        behavior: PopBehavior = PopBehavior.PRESERVE_EMPTY
+    ): NavNode? = PopOperations.pop(root, behavior)
+    
+    fun popTo(
+        root: NavNode,
+        inclusive: Boolean = false,
+        predicate: (NavNode) -> Boolean
+    ): NavNode = PopOperations.popTo(root, inclusive, predicate)
+    
+    fun popToRoute(
+        root: NavNode,
+        route: String,
+        inclusive: Boolean = false
+    ): NavNode = PopOperations.popToRoute(root, route, inclusive)
+    
+    inline fun <reified D : NavDestination> popToDestination(
+        root: NavNode,
+        inclusive: Boolean = false
+    ): NavNode = PopOperations.popToDestination<D>(root, inclusive)
+    
+    // =========================================================================
+    // TAB OPERATIONS (delegate to TabOperations)
+    // =========================================================================
+    
+    fun switchTab(
+        root: NavNode,
+        tabNodeKey: String,
+        newIndex: Int
+    ): NavNode = TabOperations.switchTab(root, tabNodeKey, newIndex)
+    
+    fun switchActiveTab(root: NavNode, newIndex: Int): NavNode = 
+        TabOperations.switchActiveTab(root, newIndex)
+    
+    // =========================================================================
+    // PANE OPERATIONS (delegate to PaneOperations)
+    // =========================================================================
+    
+    fun navigateToPane(
+        root: NavNode,
+        nodeKey: String,
+        role: PaneRole,
+        destination: NavDestination,
+        switchFocus: Boolean = true,
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PaneOperations.navigateToPane(root, nodeKey, role, destination, switchFocus, generateKey)
+    
+    fun switchActivePane(
+        root: NavNode,
+        nodeKey: String,
+        role: PaneRole
+    ): NavNode = PaneOperations.switchActivePane(root, nodeKey, role)
+    
+    fun popPane(
+        root: NavNode,
+        nodeKey: String,
+        role: PaneRole
+    ): NavNode? = PaneOperations.popPane(root, nodeKey, role)
+    
+    fun popWithPaneBehavior(root: NavNode): PopResult = 
+        PaneOperations.popWithPaneBehavior(root)
+    
+    fun popPaneAdaptive(root: NavNode, isCompact: Boolean): PopResult = 
+        PaneOperations.popPaneAdaptive(root, isCompact)
+    
+    fun setPaneConfiguration(
+        root: NavNode,
+        nodeKey: String,
+        role: PaneRole,
+        config: PaneConfiguration
+    ): NavNode = PaneOperations.setPaneConfiguration(root, nodeKey, role, config)
+    
+    fun removePaneConfiguration(
+        root: NavNode,
+        nodeKey: String,
+        role: PaneRole
+    ): NavNode = PaneOperations.removePaneConfiguration(root, nodeKey, role)
+    
+    // =========================================================================
+    // UTILITY OPERATIONS (delegate to TreeNodeOperations)
+    // =========================================================================
+    
+    fun replaceNode(root: NavNode, targetKey: String, newNode: NavNode): NavNode = 
+        TreeNodeOperations.replaceNode(root, targetKey, newNode)
+    
+    fun removeNode(root: NavNode, targetKey: String): NavNode? = 
+        TreeNodeOperations.removeNode(root, targetKey)
+    
+    // =========================================================================
+    // BACK OPERATIONS (delegate to BackOperations)
+    // =========================================================================
+    
+    fun popWithTabBehavior(root: NavNode, isCompact: Boolean = true): BackResult = 
+        BackOperations.popWithTabBehavior(root, isCompact)
+    
+    fun canGoBack(root: NavNode): Boolean = BackOperations.canGoBack(root)
+    
+    fun canHandleBackNavigation(root: NavNode): Boolean = 
+        BackOperations.canHandleBackNavigation(root)
+    
+    fun currentDestination(root: NavNode): NavDestination? = 
+        BackOperations.currentDestination(root)
+}
+```
+
+---
+
+## Alternative: Extension Functions Approach
+
+For a more Kotlin-idiomatic API, operations could also be exposed as extension functions on `NavNode`:
+
+```kotlin
+// In NavNodeExtensions.kt
+fun NavNode.push(destination: NavDestination): NavNode = 
+    PushOperations.push(this, destination, KeyGenerator.Default::generate)
+
+fun NavNode.pop(behavior: PopBehavior = PopBehavior.PRESERVE_EMPTY): NavNode? = 
+    PopOperations.pop(this, behavior)
+
+fun NavNode.switchTab(tabNodeKey: String, newIndex: Int): NavNode = 
+    TabOperations.switchTab(this, tabNodeKey, newIndex)
+
+// Usage becomes:
+val newTree = root
+    .push(HomeDestination)
+    .push(DetailDestination("123"))
+    ?.pop()
+```
+
+**Trade-off**: Extension functions are more discoverable but may pollute the `NavNode` namespace. The façade approach preserves the current API while enabling better organization internally.
+
+---
+
+## Implementation Strategy
+
+### Phase 1: Extract Types (Low Risk)
+1. Create `config/PopBehavior.kt` - move enum
+2. Create `result/PopResult.kt` - move sealed class
+3. Create `result/BackResult.kt` - move sealed class  
+4. Create `result/PushStrategy.kt` (internal) - move sealed class
+5. Create `util/KeyGenerator.kt` - extract key generation
+6. Add `@Deprecated` typealiases in `TreeMutator` for backward compatibility
+
+### Phase 2: Extract Core Operations (Medium Risk)
+1. Create `TreeNodeOperations.kt` with `replaceNode()` and `removeNode()`
+2. Update all usages to call `TreeNodeOperations` directly
+3. Keep delegating methods in `TreeMutator` façade
+
+### Phase 3: Extract Feature Operations (Medium Risk)
+Extract in order of independence (least dependencies first):
+1. `TabOperations.kt` - minimal dependencies
+2. `PopOperations.kt` - depends on TreeNodeOperations
+3. `PushOperations.kt` - depends on TreeNodeOperations, TabOperations
+4. `PaneOperations.kt` - depends on TreeNodeOperations, PopOperations
+5. `BackOperations.kt` - depends on all others
+
+### Phase 4: Cleanup & Documentation
+1. Remove implementation code from `TreeMutator.kt` (keep only delegations)
+2. Update KDoc with cross-references to specialized classes
+3. Update architecture documentation
+4. Add unit tests for each operation class
+
+---
+
+## Dependency Graph
+
+```
+                    TreeMutator (Façade)
+                          │
+     ┌────────────────────┼────────────────────┐
+     │                    │                    │
+     ▼                    ▼                    ▼
+PushOperations      PopOperations       TabOperations
+     │                    │                    
+     │                    │                    
+     ├────────────────────┼────────────────────┐
+     │                    │                    │
+     ▼                    ▼                    ▼
+PaneOperations     BackOperations      TreeNodeOperations
+     │                    │                    ▲
+     │                    │                    │
+     └────────────────────┴────────────────────┘
+```
+
+---
+
+## Metrics After Refactoring
+
+| File | Estimated Lines | Functions |
+|------|-----------------|-----------|
+| TreeMutator.kt (façade) | ~150 | ~25 (delegates) |
+| TreeNodeOperations.kt | ~100 | 2 |
+| PushOperations.kt | ~300 | 12 |
+| PopOperations.kt | ~200 | 5 |
+| TabOperations.kt | ~80 | 2 |
+| PaneOperations.kt | ~350 | 11 |
+| BackOperations.kt | ~300 | 9 |
+| Result types | ~50 | - |
+| Config types | ~20 | - |
+| **Total** | **~1,550** | **~66** |
+
+**Benefits**:
+- Each file under 400 lines ✅
+- Functions per class under 12 ✅
+- Clear single responsibility per file ✅
+- Improved testability ✅
+- Better code navigation ✅
+
+---
+
+## Backward Compatibility
+
+The refactoring maintains **100% API compatibility**:
+
+1. **TreeMutator façade** keeps all existing method signatures
+2. **Type aliases** with `@Deprecated` annotations guide migration
+3. **Import changes** only needed for direct type usage (`PopResult`, `BackResult`)
+
+```kotlin
+// Before (still works)
+val result = TreeMutator.push(root, destination)
+val canPop = TreeMutator.canGoBack(root)
+
+// After (also works)
+val result = PushOperations.push(root, destination, KeyGenerator.Default::generate)
+val canPop = BackOperations.canGoBack(root)
+
+// Kotlin extensions (optional new API)
+val result = root.push(destination)
+val canPop = root.canGoBack()
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests per Component
+
+Each operation class should have dedicated tests:
+
+```
+test/
+├── TreeNodeOperationsTest.kt
+├── PushOperationsTest.kt
+├── PopOperationsTest.kt
+├── TabOperationsTest.kt
+├── PaneOperationsTest.kt
+└── BackOperationsTest.kt
+```
+
+### Integration Tests
+
+Keep existing `TreeMutatorTest.kt` as integration tests to ensure the façade works correctly with all components.
+
+---
+
+## Timeline Estimate
+
+| Phase | Effort | Risk |
+|-------|--------|------|
+| Phase 1: Extract Types | 2 hours | Low |
+| Phase 2: Extract Core Ops | 3 hours | Medium |
+| Phase 3: Extract Feature Ops | 6 hours | Medium |
+| Phase 4: Cleanup & Docs | 2 hours | Low |
+| **Total** | **~13 hours** | |
+
+---
+
+## Open Questions
+
+1. **Extension functions vs object methods**: Should the new API favor extension functions on `NavNode`?
+   - Pros: More Kotlin-idiomatic, better discoverability
+   - Cons: Namespace pollution, harder to mock in tests
+
+2. **Internal visibility**: Should specialized operations be `internal`?
+   - Current proposal: Public for direct access, but façade is the recommended API
+   - Alternative: Make operations internal, only expose through façade
+
+3. **Key generation**: Should `KeyGenerator` be injectable through a context object?
+   - Would allow custom key generation strategies
+   - Adds complexity for minimal gain
+
+---
+
+## Conclusion
+
+This refactoring plan transforms a 1,770-line monolithic object into 7+ focused components, each with a single responsibility. The façade pattern ensures backward compatibility while enabling better organization, testability, and maintainability.
+
+The functional/immutable nature of all operations is preserved - this is purely a structural refactoring to improve code organization without changing behavior.

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/InternalQuoVadisApi.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/InternalQuoVadisApi.kt
@@ -1,0 +1,20 @@
+package com.jermey.quo.vadis.core
+
+/**
+ * Marks an API as internal to Quo Vadis library.
+ *
+ * APIs marked with this annotation are not intended for public use and may change
+ * without notice. Using these APIs requires explicit opt-in.
+ */
+@Suppress("ExperimentalAnnotationRetention")
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This is an internal Quo Vadis API that should not be used from outside the library."
+)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class InternalQuoVadisApi

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/NavigationHost.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/NavigationHost.kt
@@ -53,6 +53,7 @@ import com.jermey.quo.vadis.core.navigation.NavDestination
 import com.jermey.quo.vadis.core.navigation.route
 import com.jermey.quo.vadis.core.navigation.tree.TreeMutator
 import com.jermey.quo.vadis.core.navigation.tree.TreeNavigator
+import com.jermey.quo.vadis.core.navigation.tree.result.BackResult
 import kotlinx.coroutines.launch
 
 // =============================================================================
@@ -243,7 +244,7 @@ fun NavigationHost(
     val previousScreenNode = remember(navState, isCompact) {
         // Use popWithTabBehavior to get the correct previous screen
         val backResult = TreeMutator.popWithTabBehavior(navState, isCompact)
-        (backResult as? TreeMutator.BackResult.Handled)?.newState?.activeLeaf()
+        (backResult as? BackResult.Handled)?.newState?.activeLeaf()
     }
 
     // Create ScreenNavigationInfo for predictive back
@@ -305,7 +306,7 @@ fun NavigationHost(
             if (!backAnimationController.isAnimating) {
                 // Compute speculative pop result at gesture start using tab-aware logic
                 val backResult = TreeMutator.popWithTabBehavior(navState, isCompact)
-                val popResult = (backResult as? TreeMutator.BackResult.Handled)?.newState
+                val popResult = (backResult as? BackResult.Handled)?.newState
                 if (popResult != null) {
                     speculativePopState = popResult
 

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/PaneNavigator.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/PaneNavigator.kt
@@ -1,0 +1,62 @@
+package com.jermey.quo.vadis.core.navigation
+
+import androidx.compose.runtime.Stable
+import com.jermey.quo.vadis.core.navigation.pane.PaneRole
+
+/**
+ * Extension interface for pane-specific navigation operations.
+ *
+ * This interface extends [Navigator] with capabilities for adaptive multi-pane layouts.
+ * Use [Navigator.asPaneNavigator] to safely access these methods when available.
+ *
+ * @see Navigator
+ * @see PaneRole
+ */
+@Stable
+interface PaneNavigator : Navigator {
+
+    /**
+     * Check if a pane role is available in the current state.
+     *
+     * @param role Pane role to check
+     * @return true if the role is configured in the current PaneNode
+     */
+    fun isPaneAvailable(role: PaneRole): Boolean
+
+    /**
+     * Get the current content of a specific pane.
+     *
+     * @param role Pane role to query
+     * @return The NavNode content of the pane, or null if role not configured
+     */
+    fun paneContent(role: PaneRole): NavNode?
+
+    /**
+     * Navigate to a destination in a specific pane of an adaptive layout.
+     *
+     * Use this when you need to target a particular pane in a multi-pane layout
+     * (for example, a master–detail or split view) without changing the primary
+     * navigation stack.
+     *
+     * @param destination The destination to display in the targeted pane.
+     * @param role The [PaneRole] identifying which pane to navigate within.
+     */
+    fun navigateToPane(destination: NavDestination, role: PaneRole = PaneRole.Supporting)
+
+    /**
+     * Navigate back within a specific pane.
+     *
+     * Pops from the specified pane's stack regardless of which pane is active.
+     *
+     * @param role Pane role to pop from
+     * @return true if navigation occurred, false if pane stack was empty
+     */
+    fun navigateBackInPane(role: PaneRole): Boolean
+}
+
+/**
+ * Safely cast Navigator to PaneNavigator if supported.
+ *
+ * @return PaneNavigator instance if this Navigator supports pane operations, null otherwise
+ */
+fun Navigator.asPaneNavigator(): PaneNavigator? = this as? PaneNavigator

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/PaneNode.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/PaneNode.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 
 /**
  * Container node for adaptive pane layouts.
@@ -53,8 +52,8 @@ import kotlin.uuid.Uuid
  *
  * ## Serialization
  *
- * Only persistent navigation state is serialized. Runtime state ([uuid],
- * [isAttachedToNavigator], [isDisplayed], [composeSavedState]) is marked
+ * Only persistent navigation state is serialized. Runtime state
+ * ([isAttachedToNavigator], [isDisplayed], [composeSavedState]) is marked
  * as `@Transient` and regenerated on restoration.
  *
  * @property key Unique identifier for this pane container
@@ -88,13 +87,6 @@ class PaneNode(
     }
 
     // --- Lifecycle Infrastructure (Transient - not serialized) ---
-
-    /**
-     * Unique stable identifier for this node instance.
-     * Generated fresh on creation and after deserialization.
-     */
-    @Transient
-    val uuid: String = Uuid.random().toHexString()
 
     /**
      * Whether this node is attached to the navigator tree.

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/ResultCapable.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/ResultCapable.kt
@@ -1,0 +1,19 @@
+package com.jermey.quo.vadis.core.navigation
+
+import com.jermey.quo.vadis.core.InternalQuoVadisApi
+
+/**
+ * Internal interface for navigators that support result passing.
+ *
+ * Used internally by [navigateForResult] and [navigateBackWithResult]
+ * extension functions. Not intended for direct use.
+ *
+ * @suppress This is an internal API
+ */
+@InternalQuoVadisApi
+interface ResultCapable {
+    /**
+     * Manager for navigation result passing between screens.
+     */
+    val resultManager: NavigationResultManager
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/TransitionController.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/TransitionController.kt
@@ -1,0 +1,77 @@
+package com.jermey.quo.vadis.core.navigation
+
+import com.jermey.quo.vadis.core.InternalQuoVadisApi
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Internal interface for transition and animation control.
+ *
+ * This interface is used by the navigation framework internals (NavigationHost, renderers)
+ * to coordinate animations. Not intended for end-user consumption.
+ *
+ * @suppress This is an internal API
+ */
+@InternalQuoVadisApi
+interface TransitionController {
+
+    /**
+     * The current transition state for animations.
+     *
+     * During navigation, this holds transition metadata for animation
+     * coordination. Observe this to drive animations in the renderer.
+     */
+    val transitionState: StateFlow<TransitionState>
+
+    /**
+     * Current transition animation (null if idle).
+     *
+     * Derived from [transitionState] for convenience.
+     */
+    val currentTransition: StateFlow<NavigationTransition?>
+
+    /**
+     * Update transition progress during animations.
+     *
+     * Called by the renderer to update animation progress.
+     *
+     * @param progress Animation progress from 0.0 to 1.0
+     */
+    fun updateTransitionProgress(progress: Float)
+
+    /**
+     * Start a predictive back gesture.
+     *
+     * Called when the user initiates a back gesture.
+     */
+    fun startPredictiveBack()
+
+    /**
+     * Update predictive back gesture progress.
+     *
+     * @param progress Gesture progress from 0.0 to 1.0
+     * @param touchX Normalized x-coordinate of touch (0-1)
+     * @param touchY Normalized y-coordinate of touch (0-1)
+     */
+    fun updatePredictiveBack(progress: Float, touchX: Float, touchY: Float)
+
+    /**
+     * Cancel the predictive back gesture.
+     *
+     * Called when the user releases the gesture without completing it.
+     */
+    fun cancelPredictiveBack()
+
+    /**
+     * Commit the predictive back gesture.
+     *
+     * Called when the user completes the back gesture.
+     */
+    fun commitPredictiveBack()
+
+    /**
+     * Complete the current transition animation.
+     *
+     * Called when the animation finishes.
+     */
+    fun completeTransition()
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/TreeMutator.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/TreeMutator.kt
@@ -1,28 +1,32 @@
 package com.jermey.quo.vadis.core.navigation.tree
 
-import com.jermey.quo.vadis.core.navigation.NavNode
-import com.jermey.quo.vadis.core.navigation.PaneNode
-import com.jermey.quo.vadis.core.navigation.ScreenNode
-import com.jermey.quo.vadis.core.navigation.StackNode
-import com.jermey.quo.vadis.core.navigation.TabNode
-import com.jermey.quo.vadis.core.navigation.activeLeaf
-import com.jermey.quo.vadis.core.navigation.activePathToLeaf
-import com.jermey.quo.vadis.core.navigation.activeStack
 import com.jermey.quo.vadis.core.dsl.registry.PaneRoleRegistry
 import com.jermey.quo.vadis.core.dsl.registry.ScopeRegistry
-import com.jermey.quo.vadis.core.navigation.findByKey
 import com.jermey.quo.vadis.core.navigation.NavDestination
-import com.jermey.quo.vadis.core.navigation.pane.PaneBackBehavior
+import com.jermey.quo.vadis.core.navigation.NavNode
 import com.jermey.quo.vadis.core.navigation.pane.PaneConfiguration
 import com.jermey.quo.vadis.core.navigation.pane.PaneRole
-import com.jermey.quo.vadis.core.navigation.tree.TreeMutator.canGoBack
-import com.jermey.quo.vadis.core.navigation.tree.TreeMutator.popTo
-import com.jermey.quo.vadis.core.navigation.tree.TreeMutator.push
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
+import com.jermey.quo.vadis.core.navigation.tree.config.PopBehavior
+import com.jermey.quo.vadis.core.navigation.tree.operations.BackOperations
+import com.jermey.quo.vadis.core.navigation.tree.operations.PaneOperations
+import com.jermey.quo.vadis.core.navigation.tree.operations.PopOperations
+import com.jermey.quo.vadis.core.navigation.tree.operations.PushOperations
+import com.jermey.quo.vadis.core.navigation.tree.operations.TabOperations
+import com.jermey.quo.vadis.core.navigation.tree.operations.TreeNodeOperations
+import com.jermey.quo.vadis.core.navigation.tree.result.BackResult
+import com.jermey.quo.vadis.core.navigation.tree.result.PopResult
+import com.jermey.quo.vadis.core.navigation.tree.util.KeyGenerator
 
 /**
  * Pure functional operations for manipulating the NavNode tree.
+ *
+ * This object serves as a façade that delegates to specialized operation classes:
+ * - [PushOperations] for forward navigation
+ * - [PopOperations] for backward navigation
+ * - [TabOperations] for tab switching
+ * - [PaneOperations] for pane navigation
+ * - [BackOperations] for tree-aware back handling
+ * - [TreeNodeOperations] for low-level tree manipulation
  *
  * All operations are immutable - they return new tree instances rather than
  * modifying existing ones. This enables:
@@ -56,1705 +60,303 @@ import kotlin.uuid.Uuid
  *
  * All operations are pure functions with no mutable state, making them
  * inherently thread-safe without requiring synchronization.
+ *
+ * @see PushOperations
+ * @see PopOperations
+ * @see TabOperations
+ * @see PaneOperations
+ * @see BackOperations
+ * @see TreeNodeOperations
  */
 object TreeMutator {
 
     // =========================================================================
-    // Configuration Types
-    // =========================================================================
-
-    /**
-     * Configures behavior when a StackNode becomes empty after pop.
-     */
-    enum class PopBehavior {
-        /**
-         * Remove the empty stack from parent (cascading pop).
-         * This continues popping until a non-empty container is found.
-         */
-        CASCADE,
-
-        /**
-         * Preserve the empty stack in place.
-         * The stack remains but with no children.
-         */
-        PRESERVE_EMPTY
-    }
-
-    /**
-     * Result of a pop operation that respects PaneBackBehavior.
-     */
-    sealed class PopResult {
-        /** Successfully popped within current pane */
-        data class Popped(val newState: NavNode) : PopResult()
-
-        /** Pane is empty, behavior depends on PaneBackBehavior */
-        data class PaneEmpty(val paneRole: PaneRole) : PopResult()
-
-        /** Cannot pop - would leave tree in invalid state */
-        data object CannotPop : PopResult()
-
-        /** Back behavior requires scaffold/visual change (renderer must handle) */
-        data object RequiresScaffoldChange : PopResult()
-    }
-
-    /**
-     * Result of a tree-aware back operation.
-     */
-    sealed class BackResult {
-        /** Back was handled, new tree state returned */
-        data class Handled(val newState: NavNode) : BackResult()
-
-        /** Back should be delegated to system (e.g., close app) */
-        data object DelegateToSystem : BackResult()
-
-        /** Back could not be handled (internal error) */
-        data object CannotHandle : BackResult()
-    }
-
-    /**
-     * Result of a push operation with tab awareness.
-     *
-     * Used internally to determine how a push should be handled when
-     * navigating within a TabNode context.
-     */
-    sealed class PushStrategy {
-        /** Push to the specified stack normally */
-        data class PushToStack(val targetStack: StackNode) : PushStrategy()
-
-        /** Switch to an existing tab that contains the destination */
-        data class SwitchToTab(val tabNode: TabNode, val tabIndex: Int) : PushStrategy()
-
-        /** Push to a specific pane's stack within a PaneNode */
-        data class PushToPaneStack(val paneNode: PaneNode, val role: PaneRole) : PushStrategy()
-
-        /** Destination is out of scope - push to parent stack */
-        data class PushOutOfScope(val parentStack: StackNode) : PushStrategy()
-    }
-
-    // =========================================================================
-    // PUSH OPERATIONS
+    // PUSH OPERATIONS (delegate to PushOperations)
     // =========================================================================
 
     /**
      * Push a destination onto the deepest active stack.
      *
-     * Traverses the tree following the active path (active children of TabNodes,
-     * active panes of PaneNodes) until reaching the deepest StackNode, then
-     * appends a new ScreenNode with the given destination.
-     *
-     * ## Example
-     *
-     * ```kotlin
-     * // Given a tree: StackNode -> TabNode -> StackNode(active)
-     * val newTree = TreeMutator.push(root, ProfileDestination)
-     * // ProfileDestination is pushed to the innermost active StackNode
-     * ```
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param destination The destination to navigate to
-     * @param generateKey Function to generate unique keys for new nodes
-     * @return New tree with the destination pushed to the active stack
-     * @throws IllegalStateException if no active stack is found
+     * @see PushOperations.push
      */
-    @OptIn(ExperimentalUuidApi::class)
     fun push(
         root: NavNode,
         destination: NavDestination,
-        generateKey: () -> String = { Uuid.random().toString().take(8) }
-    ): NavNode {
-        val targetStack = root.activeStack()
-            ?: throw IllegalStateException("No active stack found in tree")
-
-        val newScreen = ScreenNode(
-            key = generateKey(),
-            parentKey = targetStack.key,
-            destination = destination
-        )
-
-        val newStack = targetStack.copy(
-            children = targetStack.children + newScreen
-        )
-
-        return replaceNode(root, targetStack.key, newStack)
-    }
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.push(root, destination, generateKey)
 
     /**
      * Push a destination onto a specific stack identified by key.
      *
-     * Unlike [push], this allows targeting a specific stack regardless of
-     * whether it's currently active. Useful for pre-populating tab stacks
-     * or background navigation.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param stackKey Key of the target StackNode
-     * @param destination The destination to push
-     * @param generateKey Function to generate unique keys for new nodes
-     * @return New tree with the destination pushed to the specified stack
-     * @throws IllegalArgumentException if stackKey doesn't exist or isn't a StackNode
+     * @see PushOperations.pushToStack
      */
-    @OptIn(ExperimentalUuidApi::class)
     fun pushToStack(
         root: NavNode,
         stackKey: String,
         destination: NavDestination,
-        generateKey: () -> String = { Uuid.random().toString().take(8) }
-    ): NavNode {
-        val targetNode = root.findByKey(stackKey)
-            ?: throw IllegalArgumentException("Node with key '$stackKey' not found")
-
-        require(targetNode is StackNode) {
-            "Node '$stackKey' is ${targetNode::class.simpleName}, expected StackNode"
-        }
-
-        val newScreen = ScreenNode(
-            key = generateKey(),
-            parentKey = stackKey,
-            destination = destination
-        )
-
-        val newStack = targetNode.copy(
-            children = targetNode.children + newScreen
-        )
-
-        return replaceNode(root, stackKey, newStack)
-    }
-
-    // =========================================================================
-    // SCOPE-AWARE PUSH OPERATIONS
-    // =========================================================================
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.pushToStack(root, stackKey, destination, generateKey)
 
     /**
      * Push a destination with scope awareness, tab switching, and pane role routing.
      *
-     * Navigation logic:
-     * 1. First check if destination is in scope (using [scopeRegistry])
-     * 2. For TabNode: check if destination already exists in any tab's stack
-     *    - If found in another tab's stack, switch to that tab instead of pushing
-     * 3. For PaneNode: check if destination has a specific pane role (using [paneRoleRegistry])
-     *    - If destination has a role, push to that pane's stack
-     * 4. If out of scope, delegate to parent stack
-     *
-     * ## Scope Resolution
-     *
-     * The method walks up from the deepest active stack, checking each container
-     * (TabNode/PaneNode) with a [scopeKey][TabNode.scopeKey]. If the destination
-     * is not in that scope (according to [scopeRegistry]), navigation targets
-     * the parent stack instead.
-     *
-     * ## Tab Switching
-     *
-     * When navigating to a destination that already exists in a different tab's
-     * stack (within the same TabNode), the navigator will switch to that tab
-     * instead of creating a duplicate entry.
-     *
-     * ## Pane Role Routing
-     *
-     * When inside a PaneNode context, the [paneRoleRegistry] determines which
-     * pane a destination belongs to. If the destination has a registered role,
-     * navigation pushes to that pane's stack instead of the active stack.
-     *
-     * ## Example
-     *
-     * ```kotlin
-     * // Given: Root -> Stack -> PaneNode(scopeKey="messages") -> Stack(PRIMARY, active)
-     *
-     * // ConversationDetail has paneRole=SECONDARY - pushes to SECONDARY pane's stack
-     * TreeMutator.push(root, ConversationDetail("123"), scopeRegistry, paneRoleRegistry)
-     *
-     * // DetailDestination is NOT in scope - pushes to parent stack (above PaneNode)
-     * TreeMutator.push(root, DetailDestination, scopeRegistry, paneRoleRegistry)
-     * ```
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param destination The destination to navigate to
-     * @param scopeRegistry Registry to check scope membership
-     * @param paneRoleRegistry Registry to determine pane roles for destinations
-     * @param generateKey Function to generate unique keys for new nodes
-     * @return New tree with the destination pushed or tab switched appropriately
-     * @throws IllegalStateException if no suitable stack is found
+     * @see PushOperations.push
      */
-    @OptIn(ExperimentalUuidApi::class)
     fun push(
         root: NavNode,
         destination: NavDestination,
         scopeRegistry: ScopeRegistry,
         paneRoleRegistry: PaneRoleRegistry = PaneRoleRegistry.Empty,
-        generateKey: () -> String = { Uuid.random().toString().take(8) }
-    ): NavNode {
-        // If no scope registry (or Empty), use the simple push
-        if (scopeRegistry === ScopeRegistry.Empty && paneRoleRegistry === PaneRoleRegistry.Empty) {
-            return push(root, destination, generateKey)
-        }
-
-        return when (val strategy = determinePushStrategy(root, destination, scopeRegistry, paneRoleRegistry)) {
-            is PushStrategy.PushToStack -> {
-                pushToActiveStack(root, strategy.targetStack, destination, generateKey)
-            }
-
-            is PushStrategy.SwitchToTab -> {
-                switchTab(root, strategy.tabNode.key, strategy.tabIndex)
-            }
-
-            is PushStrategy.PushToPaneStack -> {
-                pushToPaneStack(root, strategy.paneNode, strategy.role, destination, generateKey)
-            }
-
-            is PushStrategy.PushOutOfScope -> {
-                pushOutOfScope(root, strategy.parentStack, destination, generateKey)
-            }
-        }
-    }
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode =
+        PushOperations.push(root, destination, scopeRegistry, paneRoleRegistry, generateKey)
 
     /**
-     * Determines the push strategy for a destination considering scope, tabs, and pane roles.
+     * Push multiple destinations at once.
      *
-     * Walks up from the deepest active stack, checking each container (TabNode/PaneNode)
-     * to determine how the navigation should be handled.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param destination The destination to check
-     * @param scopeRegistry Registry for scope membership checks
-     * @param paneRoleRegistry Registry for pane role lookups
-     * @return The appropriate PushStrategy for this navigation
-     * @throws IllegalStateException if no valid strategy can be determined
+     * @see PushOperations.pushAll
      */
-    private fun determinePushStrategy(
+    fun pushAll(
+        root: NavNode,
+        destinations: List<NavDestination>,
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.pushAll(root, destinations, generateKey)
+
+    /**
+     * Clear a stack and push a single screen.
+     *
+     * @see PushOperations.clearAndPush
+     */
+    fun clearAndPush(
         root: NavNode,
         destination: NavDestination,
-        scopeRegistry: ScopeRegistry,
-        paneRoleRegistry: PaneRoleRegistry = PaneRoleRegistry.Empty
-    ): PushStrategy {
-        val activeStack = root.activeStack()
-            ?: throw IllegalStateException("No active stack found in tree")
-
-        // Walk the active path to find containers
-        val activePath = root.activePathToLeaf()
-
-        // Check containers from deepest to shallowest
-        for (node in activePath.reversed()) {
-            when (node) {
-                is StackNode -> {
-                    // Check if this stack has a scope and if destination is out of scope
-                    val stackScope = node.scopeKey
-                    if (stackScope != null && !scopeRegistry.isInScope(stackScope, destination)) {
-                        // Out of scope - find the stack that contains this StackNode
-                        val parentKey = node.parentKey ?: continue
-                        val parent = root.findByKey(parentKey)
-                        if (parent is StackNode) {
-                            return PushStrategy.PushOutOfScope(parent)
-                        }
-                    }
-                }
-
-                is TabNode -> {
-                    val scopeKey = node.scopeKey
-
-                    // First, check if destination is in scope
-                    if (scopeKey != null && !scopeRegistry.isInScope(scopeKey, destination)) {
-                        // Out of scope - find the stack that contains this TabNode
-                        val parentKey = node.parentKey ?: continue
-                        val parent = root.findByKey(parentKey)
-                        if (parent is StackNode) {
-                            return PushStrategy.PushOutOfScope(parent)
-                        }
-                        continue
-                    }
-
-                    // Destination is in scope - check if it exists in any tab's stack
-                    val existingTabIndex = findTabWithDestination(node, destination)
-                    if (existingTabIndex != null && existingTabIndex != node.activeStackIndex) {
-                        // Destination exists in a different tab - switch to it
-                        return PushStrategy.SwitchToTab(node, existingTabIndex)
-                    }
-
-                    // Destination is in scope but not in another tab - push to active stack
-                    // Continue checking other containers up the tree
-                }
-
-                is PaneNode -> {
-                    val scopeKey = node.scopeKey
-                    if (scopeKey != null && !scopeRegistry.isInScope(scopeKey, destination)) {
-                        // Out of scope - find the stack that contains this PaneNode
-                        val parentKey = node.parentKey ?: continue
-                        val parent = root.findByKey(parentKey)
-                        if (parent is StackNode) {
-                            return PushStrategy.PushOutOfScope(parent)
-                        }
-                        continue
-                    }
-
-                    // Destination is in scope - check if it has a specific pane role
-                    if (scopeKey != null) {
-                        val targetRole = paneRoleRegistry.getPaneRole(scopeKey, destination)
-                        if (targetRole != null && node.paneConfigurations.containsKey(targetRole)) {
-                            // Destination has a registered pane role - push to that pane's stack
-                            return PushStrategy.PushToPaneStack(node, targetRole)
-                        }
-                    }
-                }
-
-                else -> { /* Continue checking */
-                }
-            }
-        }
-
-        // All containers allow this destination, push to deepest active stack
-        return PushStrategy.PushToStack(activeStack)
-    }
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.clearAndPush(root, destination, generateKey)
 
     /**
-     * Finds the tab index containing a destination with matching type.
+     * Clear a specific stack and push a single screen.
      *
-     * Searches through all stacks in a TabNode to find one that contains
-     * a ScreenNode with a destination of the same type (class) as the target.
-     *
-     * @param tabNode The TabNode to search within
-     * @param destination The destination to find
-     * @return The tab index if found, null otherwise
+     * @see PushOperations.clearStackAndPush
      */
-    private fun findTabWithDestination(tabNode: TabNode, destination: NavDestination): Int? {
-        val destinationClass = destination::class
-        tabNode.stacks.forEachIndexed { index, stack ->
-            // Check if this stack contains a screen with matching destination type
-            val hasDestination = stack.children.any { child ->
-                child is ScreenNode && child.destination::class == destinationClass
-            }
-            if (hasDestination) {
-                return index
-            }
-        }
-        return null
-    }
-
-    /**
-     * Push directly to a specific stack (in-scope case).
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param targetStack The stack to push to
-     * @param destination The destination to push
-     * @param generateKey Function to generate unique keys for new nodes
-     * @return New tree with the destination pushed to the target stack
-     */
-    @OptIn(ExperimentalUuidApi::class)
-    private fun pushToActiveStack(
+    fun clearStackAndPush(
         root: NavNode,
-        targetStack: StackNode,
+        stackKey: String,
         destination: NavDestination,
-        generateKey: () -> String
-    ): NavNode {
-        val newScreen = ScreenNode(
-            key = generateKey(),
-            parentKey = targetStack.key,
-            destination = destination
-        )
-
-        val newStack = targetStack.copy(
-            children = targetStack.children + newScreen
-        )
-
-        return replaceNode(root, targetStack.key, newStack)
-    }
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.clearStackAndPush(root, stackKey, destination, generateKey)
 
     /**
-     * Push a destination outside the current container's scope.
+     * Replace the currently active screen with a new destination.
      *
-     * Creates a new ScreenNode as a child of the parent stack, effectively
-     * navigating "on top of" the container. This preserves the container
-     * (and its state) for back navigation.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param parentStack The stack to push to (parent of the scoped container)
-     * @param destination The destination to push
-     * @param generateKey Function to generate unique keys for new nodes
-     * @return New tree with the destination pushed to the parent stack
+     * @see PushOperations.replaceCurrent
      */
-    @OptIn(ExperimentalUuidApi::class)
-    private fun pushOutOfScope(
+    fun replaceCurrent(
         root: NavNode,
-        parentStack: StackNode,
         destination: NavDestination,
-        generateKey: () -> String
-    ): NavNode {
-        val screenKey = generateKey()
-
-        // Create new screen as direct child of parent stack
-        val newScreen = ScreenNode(
-            key = screenKey,
-            parentKey = parentStack.key,
-            destination = destination
-        )
-
-        // Add new screen to parent stack's children
-        val updatedParentStack = parentStack.copy(
-            children = parentStack.children + newScreen
-        )
-
-        return replaceNode(root, parentStack.key, updatedParentStack)
-    }
-
-    /**
-     * Push a destination to a specific pane's stack within a PaneNode.
-     *
-     * Finds the stack for the given pane role and pushes the destination there,
-     * optionally switching the active pane to the target role.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param paneNode The PaneNode containing the target pane
-     * @param role The pane role to push to
-     * @param destination The destination to push
-     * @param generateKey Function to generate unique keys for new nodes
-     * @return New tree with the destination pushed to the pane's stack
-     */
-    @OptIn(ExperimentalUuidApi::class)
-    private fun pushToPaneStack(
-        root: NavNode,
-        paneNode: PaneNode,
-        role: PaneRole,
-        destination: NavDestination,
-        generateKey: () -> String
-    ): NavNode {
-        val paneConfig = paneNode.paneConfigurations[role]
-            ?: return root // Role not configured, return unchanged
-
-        val paneStack = paneConfig.content as? StackNode
-            ?: return root // Content is not a StackNode, return unchanged
-
-        // Create new screen node
-        val screenKey = generateKey()
-        val newScreen = ScreenNode(
-            key = screenKey,
-            parentKey = paneStack.key,
-            destination = destination
-        )
-
-        // Update the pane's stack with the new screen
-        val updatedStack = paneStack.copy(
-            children = paneStack.children + newScreen
-        )
-
-        // Update the pane configuration with the new stack
-        val updatedPaneConfig = paneConfig.copy(content = updatedStack)
-        val updatedPaneConfigurations = paneNode.paneConfigurations.toMutableMap()
-        updatedPaneConfigurations[role] = updatedPaneConfig
-
-        // Update the PaneNode with new configurations AND switch active pane
-        val updatedPaneNode = paneNode.copy(
-            paneConfigurations = updatedPaneConfigurations,
-            activePaneRole = role // Switch focus to the target pane
-        )
-
-        return replaceNode(root, paneNode.key, updatedPaneNode)
-    }
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode = PushOperations.replaceCurrent(root, destination, generateKey)
 
     // =========================================================================
-    // POP OPERATIONS
+    // POP OPERATIONS (delegate to PopOperations)
     // =========================================================================
 
     /**
      * Pop the active screen from the deepest active stack.
      *
-     * Removes the last child from the deepest active StackNode. The [behavior]
-     * parameter controls what happens if the stack becomes empty after popping.
-     *
-     * ## Cascade Behavior
-     *
-     * With [PopBehavior.CASCADE], if popping leaves a stack empty:
-     * - The empty stack is removed from its parent
-     * - This may recursively propagate up the tree
-     * - Returns null if popping would leave the root empty
-     *
-     * ## Example
-     *
-     * ```kotlin
-     * val result = TreeMutator.pop(root, PopBehavior.PRESERVE_EMPTY)
-     * if (result == null) {
-     *     // Cannot pop - at root or tree is empty
-     * }
-     * ```
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param behavior How to handle an empty stack after popping
-     * @return New tree with the top screen popped, or null if cannot pop
+     * @see PopOperations.pop
      */
     fun pop(
         root: NavNode,
         behavior: PopBehavior = PopBehavior.PRESERVE_EMPTY
-    ): NavNode? {
-        val targetStack = root.activeStack() ?: return null
-
-        // Cannot pop from empty stack
-        if (targetStack.isEmpty) return null
-
-        // Pop the last child
-        val newChildren = targetStack.children.dropLast(1)
-
-        // Handle empty stack based on behavior
-        if (newChildren.isEmpty()) {
-            return handleEmptyStackPop(root, targetStack, behavior)
-        }
-
-        val newStack = targetStack.copy(children = newChildren)
-        return replaceNode(root, targetStack.key, newStack)
-    }
+    ): NavNode? = PopOperations.pop(root, behavior)
 
     /**
      * Pop all screens from the active stack until the predicate matches.
      *
-     * Searches from the back (most recent) to the front of the active stack
-     * for a node matching the predicate. All nodes after the match are removed.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param inclusive If true, also removes the matching node
-     * @param predicate Function to identify the target node
-     * @return New tree with nodes popped, or original tree if no match found
+     * @see PopOperations.popTo
      */
     fun popTo(
         root: NavNode,
         inclusive: Boolean = false,
         predicate: (NavNode) -> Boolean
-    ): NavNode {
-        val targetStack = root.activeStack() ?: return root
-
-        // Find the index of the matching node (searching from back to front)
-        val matchIndex = targetStack.children.indexOfLast { predicate(it) }
-        if (matchIndex == -1) return root
-
-        // Calculate how many to keep
-        val keepCount = if (inclusive) matchIndex else matchIndex + 1
-        if (keepCount == 0) return root // Would make stack empty
-
-        val newChildren = targetStack.children.take(keepCount)
-        val newStack = targetStack.copy(children = newChildren)
-        return replaceNode(root, targetStack.key, newStack)
-    }
+    ): NavNode = PopOperations.popTo(root, inclusive, predicate)
 
     /**
      * Pop to a screen with the given route.
      *
-     * Convenience wrapper around [popTo] that matches by destination route.
-     * Compares the route against [Destination.toString] or a route property
-     * if available.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param route The route string to match
-     * @param inclusive If true, also removes the matching screen
-     * @return New tree with nodes popped, or original tree if route not found
+     * @see PopOperations.popToRoute
      */
     fun popToRoute(
         root: NavNode,
         route: String,
         inclusive: Boolean = false
-    ): NavNode {
-        return popTo(root, inclusive) { node ->
-            node is ScreenNode && node.destination.toString() == route
-        }
-    }
+    ): NavNode = PopOperations.popToRoute(root, route, inclusive)
 
     /**
      * Pop to a screen with destination matching the given type.
      *
-     * @param root The root NavNode of the navigation tree
-     * @param inclusive If true, also removes the matching screen
-     * @return New tree with nodes popped, or original tree if not found
+     * @see PopOperations.popToDestination
      */
     inline fun <reified D : NavDestination> popToDestination(
         root: NavNode,
         inclusive: Boolean = false
-    ): NavNode {
-        return popTo(root, inclusive) { node ->
-            node is ScreenNode && node.destination is D
-        }
-    }
-
-    /**
-     * Handle pop when the active stack would become empty.
-     */
-    private fun handleEmptyStackPop(
-        root: NavNode,
-        emptyStack: StackNode,
-        behavior: PopBehavior
-    ): NavNode? {
-        return when (behavior) {
-            PopBehavior.PRESERVE_EMPTY -> {
-                // Just update to empty stack
-                val newStack = emptyStack.copy(children = emptyList())
-                replaceNode(root, emptyStack.key, newStack)
-            }
-
-            PopBehavior.CASCADE -> {
-                // If this is the root, cannot cascade further
-                if (emptyStack.parentKey == null) return null
-
-                // Try to remove this stack from its parent
-                val parent = root.findByKey(emptyStack.parentKey)
-                    ?: return null // Parent not found, cannot cascade
-
-                when (parent) {
-                    is TabNode -> {
-                        // Cannot remove a tab's stack - that would break the tab structure
-                        // Instead, just preserve the empty stack
-                        val newStack = emptyStack.copy(children = emptyList())
-                        replaceNode(root, emptyStack.key, newStack)
-                    }
-
-                    is StackNode -> {
-                        // Remove the empty stack from parent's children
-                        removeNode(root, emptyStack.key)
-                    }
-
-                    is PaneNode -> {
-                        // Cannot remove a pane's content - preserve empty
-                        val newStack = emptyStack.copy(children = emptyList())
-                        replaceNode(root, emptyStack.key, newStack)
-                    }
-
-                    is ScreenNode -> {
-                        // ScreenNode cannot be a parent - this shouldn't happen
-                        null
-                    }
-                }
-            }
-        }
-    }
+    ): NavNode = PopOperations.popToDestination<D>(root, inclusive)
 
     // =========================================================================
-    // TAB OPERATIONS
+    // TAB OPERATIONS (delegate to TabOperations)
     // =========================================================================
 
     /**
      * Switch to a different tab in a TabNode.
      *
-     * Updates the [TabNode.activeStackIndex] to the specified index.
-     * The stacks themselves are unchanged - each tab preserves its history.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param tabNodeKey Key of the TabNode to modify
-     * @param newIndex The tab index to switch to (0-based)
-     * @return New tree with the tab switched
-     * @throws IllegalArgumentException if tabNodeKey not found or not a TabNode
-     * @throws IndexOutOfBoundsException if newIndex is out of bounds
+     * @see TabOperations.switchTab
      */
     fun switchTab(
         root: NavNode,
         tabNodeKey: String,
         newIndex: Int
-    ): NavNode {
-        val tabNode = root.findByKey(tabNodeKey) as? TabNode
-            ?: throw IllegalArgumentException("TabNode with key '$tabNodeKey' not found")
-
-        require(newIndex in 0 until tabNode.tabCount) {
-            "Tab index $newIndex out of bounds for ${tabNode.tabCount} tabs"
-        }
-
-        if (tabNode.activeStackIndex == newIndex) return root
-
-        val newTabNode = tabNode.copy(activeStackIndex = newIndex)
-        return replaceNode(root, tabNodeKey, newTabNode)
-    }
+    ): NavNode = TabOperations.switchTab(root, tabNodeKey, newIndex)
 
     /**
      * Switch to a different tab in the first TabNode found in the active path.
      *
-     * Traverses the active path to find the first TabNode, then switches
-     * to the specified tab index. Useful when you don't know or don't want
-     * to specify the exact TabNode key.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param newIndex The tab index to switch to (0-based)
-     * @return New tree with the tab switched
-     * @throws IllegalStateException if no TabNode found in active path
+     * @see TabOperations.switchActiveTab
      */
-    fun switchActiveTab(root: NavNode, newIndex: Int): NavNode {
-        // Find the first TabNode in the active path
-        val activePath = root.activePathToLeaf()
-        val tabNode = activePath.filterIsInstance<TabNode>().firstOrNull()
-            ?: throw IllegalStateException("No TabNode found in active path")
-
-        return switchTab(root, tabNode.key, newIndex)
-    }
+    fun switchActiveTab(root: NavNode, newIndex: Int): NavNode =
+        TabOperations.switchActiveTab(root, newIndex)
 
     // =========================================================================
-    // PANE OPERATIONS (from CORE-002 Impact Notes)
+    // PANE OPERATIONS (delegate to PaneOperations)
     // =========================================================================
 
     /**
      * Navigates to a destination within the specified pane role.
      *
-     * If the pane contains a StackNode (directly or as content), pushes the
-     * destination onto that stack. Optionally switches [PaneNode.activePaneRole]
-     * to the target pane.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param nodeKey Key of the PaneNode to mutate
-     * @param role Target pane role
-     * @param destination Destination to navigate to
-     * @param switchFocus Whether to also set activePaneRole to this role
-     * @param generateKey Function to generate unique keys for new nodes
-     * @return New tree with navigation applied
-     * @throws IllegalArgumentException if nodeKey not found or role not configured
+     * @see PaneOperations.navigateToPane
      */
-    @OptIn(ExperimentalUuidApi::class)
     fun navigateToPane(
         root: NavNode,
         nodeKey: String,
         role: PaneRole,
         destination: NavDestination,
         switchFocus: Boolean = true,
-        generateKey: () -> String = { Uuid.random().toString().take(8) }
-    ): NavNode {
-        val paneNode = root.findByKey(nodeKey) as? PaneNode
-            ?: throw IllegalArgumentException("PaneNode with key '$nodeKey' not found")
-
-        val paneConfig = paneNode.paneConfigurations[role]
-            ?: throw IllegalArgumentException("Pane role $role not configured in PaneNode '$nodeKey'")
-
-        // Find or create a stack in this pane's content
-        val paneContent = paneConfig.content
-        val targetStack = when (paneContent) {
-            is StackNode -> paneContent
-            else -> paneContent.activeStack()
-                ?: throw IllegalStateException("No stack found in pane $role content")
-        }
-
-        // Create new screen
-        val newScreen = ScreenNode(
-            key = generateKey(),
-            parentKey = targetStack.key,
-            destination = destination
-        )
-
-        // Update the stack
-        val newStack = targetStack.copy(children = targetStack.children + newScreen)
-
-        // Replace the stack in the tree
-        var result = replaceNode(root, targetStack.key, newStack)
-
-        // Optionally switch focus
-        if (switchFocus && paneNode.activePaneRole != role) {
-            result = switchActivePane(result, nodeKey, role)
-        }
-
-        return result
-    }
+        generateKey: () -> String = KeyGenerator.Default::generate
+    ): NavNode =
+        PaneOperations.navigateToPane(root, nodeKey, role, destination, switchFocus, generateKey)
 
     /**
      * Switches the active pane role without navigating.
      *
-     * This affects which pane receives subsequent navigation operations
-     * and may influence visibility on compact screens.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param nodeKey Key of the PaneNode to mutate
-     * @param role New active pane role (must exist in paneConfigurations)
-     * @return New tree with active pane switched
-     * @throws IllegalArgumentException if nodeKey not found or role not configured
+     * @see PaneOperations.switchActivePane
      */
     fun switchActivePane(
         root: NavNode,
         nodeKey: String,
         role: PaneRole
-    ): NavNode {
-        val paneNode = root.findByKey(nodeKey) as? PaneNode
-            ?: throw IllegalArgumentException("PaneNode with key '$nodeKey' not found")
-
-        require(paneNode.paneConfigurations.containsKey(role)) {
-            "Pane role $role not configured in PaneNode '$nodeKey'"
-        }
-
-        if (paneNode.activePaneRole == role) return root
-
-        val newPaneNode = paneNode.copy(activePaneRole = role)
-        return replaceNode(root, nodeKey, newPaneNode)
-    }
+    ): NavNode = PaneOperations.switchActivePane(root, nodeKey, role)
 
     /**
      * Pops the top entry from the specified pane's stack.
      *
-     * @param root The root NavNode of the navigation tree
-     * @param nodeKey Key of the PaneNode to mutate
-     * @param role Pane role to pop from
-     * @return Updated NavNode, or null if the pane's stack is empty
+     * @see PaneOperations.popPane
      */
     fun popPane(
         root: NavNode,
         nodeKey: String,
         role: PaneRole
-    ): NavNode? {
-        val paneNode = root.findByKey(nodeKey) as? PaneNode
-            ?: throw IllegalArgumentException("PaneNode with key '$nodeKey' not found")
-
-        val paneConfig = paneNode.paneConfigurations[role]
-            ?: throw IllegalArgumentException("Pane role $role not configured in PaneNode '$nodeKey'")
-
-        // Find the stack in this pane
-        val paneContent = paneConfig.content
-        val targetStack = when (paneContent) {
-            is StackNode -> paneContent
-            else -> paneContent.activeStack() ?: return null
-        }
-
-        // Cannot pop from empty stack
-        if (targetStack.isEmpty || targetStack.children.size <= 1) return null
-
-        val newChildren = targetStack.children.dropLast(1)
-        val newStack = targetStack.copy(children = newChildren)
-        return replaceNode(root, targetStack.key, newStack)
-    }
+    ): NavNode? = PaneOperations.popPane(root, nodeKey, role)
 
     /**
      * Pop with respect to PaneBackBehavior.
      *
-     * This operation considers the [PaneBackBehavior] setting of the active
-     * PaneNode (if any) and returns a [PopResult] indicating what action
-     * was taken or should be taken.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @return PopResult indicating the outcome
+     * @see PaneOperations.popWithPaneBehavior
      */
-    fun popWithPaneBehavior(root: NavNode): PopResult {
-        // Find if we're in a PaneNode context
-        val activePath = root.activePathToLeaf()
-        val paneNode = activePath.filterIsInstance<PaneNode>().lastOrNull()
-
-        // If no PaneNode, just do a regular pop
-        if (paneNode == null) {
-            return pop(root)?.let { PopResult.Popped(it) } ?: PopResult.CannotPop
-        }
-
-        val activeStack = root.activeStack() ?: return PopResult.CannotPop
-
-        // If stack has content to pop, pop it
-        if (activeStack.children.size > 1) {
-            return pop(root)?.let { PopResult.Popped(it) } ?: PopResult.CannotPop
-        }
-
-        // Stack would become empty or is at root - apply PaneBackBehavior
-        return when (paneNode.backBehavior) {
-            PaneBackBehavior.PopLatest -> {
-                // Simple pop - if we can't, we can't
-                pop(root)?.let { PopResult.Popped(it) } ?: PopResult.CannotPop
-            }
-
-            PaneBackBehavior.PopUntilScaffoldValueChange -> {
-                // Try to switch to Primary pane if we're in a different pane
-                if (paneNode.activePaneRole != PaneRole.Primary) {
-                    val newRoot = switchActivePane(root, paneNode.key, PaneRole.Primary)
-                    PopResult.Popped(newRoot)
-                } else {
-                    // Already on Primary, renderer needs to handle scaffold change
-                    PopResult.RequiresScaffoldChange
-                }
-            }
-
-            PaneBackBehavior.PopUntilCurrentDestinationChange -> {
-                // Try switching to a different pane with content
-                val alternativePanes = paneNode.configuredRoles
-                    .filter { it != paneNode.activePaneRole }
-                    .filter { role ->
-                        val content = paneNode.paneContent(role)
-                        content?.activeStack()?.children?.isNotEmpty() == true
-                    }
-
-                if (alternativePanes.isNotEmpty()) {
-                    val newRole = alternativePanes.first()
-                    val newRoot = switchActivePane(root, paneNode.key, newRole)
-                    PopResult.Popped(newRoot)
-                } else {
-                    PopResult.PaneEmpty(paneNode.activePaneRole)
-                }
-            }
-
-            PaneBackBehavior.PopUntilContentChange -> {
-                // Pop from any pane that has content
-                val panesWithContent = paneNode.configuredRoles.filter { role ->
-                    val content = paneNode.paneContent(role)
-                    val stack = content?.activeStack()
-                    stack != null && stack.children.size > 1
-                }
-
-                if (panesWithContent.isNotEmpty()) {
-                    // Pop from the first pane with content (preferring active)
-                    val targetRole = if (paneNode.activePaneRole in panesWithContent) {
-                        paneNode.activePaneRole
-                    } else {
-                        panesWithContent.first()
-                    }
-                    val poppedResult = popPane(root, paneNode.key, targetRole)
-                    if (poppedResult != null) {
-                        // After popping, check if the target pane returned to root state
-                        // If so, and it's not PRIMARY, clear the pane and switch to PRIMARY
-                        val updatedPaneNode = poppedResult.findByKey(paneNode.key) as? PaneNode
-                        if (updatedPaneNode != null && targetRole != PaneRole.Primary) {
-                            val targetStack = updatedPaneNode.paneContent(targetRole)?.activeStack()
-                            if (targetStack != null && targetStack.children.size <= 1) {
-                                // Target pane is now at root - clear it and switch to PRIMARY
-                                var newState = clearPaneStack(poppedResult, paneNode.key, targetRole)
-                                newState = switchActivePane(newState, paneNode.key, PaneRole.Primary)
-                                return PopResult.Popped(newState)
-                            }
-                        }
-                        PopResult.Popped(poppedResult)
-                    } else {
-                        PopResult.PaneEmpty(paneNode.activePaneRole)
-                    }
-                } else {
-                    // No panes have content to pop
-                    // If we're on a non-PRIMARY pane, clear it and switch to PRIMARY
-                    if (paneNode.activePaneRole != PaneRole.Primary) {
-                        var newRoot = clearPaneStack(root, paneNode.key, paneNode.activePaneRole)
-                        newRoot = switchActivePane(newRoot, paneNode.key, PaneRole.Primary)
-                        PopResult.Popped(newRoot)
-                    } else {
-                        PopResult.PaneEmpty(paneNode.activePaneRole)
-                    }
-                }
-            }
-        }
-    }
+    fun popWithPaneBehavior(root: NavNode): PopResult =
+        PaneOperations.popWithPaneBehavior(root)
 
     /**
      * Pop from a pane with awareness of window size.
      *
-     * In compact mode (single pane visible), back behaves like a simple stack,
-     * ignoring the configured [PaneBackBehavior]. This ensures predictable
-     * back navigation when only one pane is shown.
-     *
-     * In expanded mode (multiple panes visible), the configured [PaneBackBehavior]
-     * applies, allowing for sophisticated multi-pane back behaviors.
-     *
-     * @param root The root NavNode
-     * @param isCompact Whether currently in compact/single-pane mode
-     * @return PopResult indicating the outcome
+     * @see PaneOperations.popPaneAdaptive
      */
-    fun popPaneAdaptive(root: NavNode, isCompact: Boolean): PopResult {
-        // Find the active pane node if any
-        val activePath = root.activePathToLeaf()
-        val paneNode = activePath.filterIsInstance<PaneNode>().firstOrNull()
-
-        if (paneNode == null) {
-            // No pane node - use standard pop
-            val result = pop(root)
-            return if (result != null) PopResult.Popped(result) else PopResult.CannotPop
-        }
-
-        if (isCompact) {
-            // In compact mode, treat as simple stack
-            // Just pop from the active stack, ignoring pane configuration
-            return popFromActivePane(root, paneNode)
-        }
-
-        // In expanded mode, use configured behavior
-        return popWithPaneBehavior(root)
-    }
-
-    /**
-     * Simple pop from the active pane's stack.
-     *
-     * This is used in compact mode where we want simple stack-like
-     * back navigation regardless of pane configuration.
-     *
-     * @param root The root NavNode
-     * @param paneNode The PaneNode to pop from
-     * @return PopResult indicating the outcome
-     */
-    private fun popFromActivePane(root: NavNode, paneNode: PaneNode): PopResult {
-        val activePaneRole = paneNode.activePaneRole
-        val activeStack = paneNode.activePaneContent?.activeStack()
-
-        if (activeStack == null) {
-            return PopResult.PaneEmpty(activePaneRole)
-        }
-
-        if (activeStack.children.size <= 1) {
-            // Stack would become empty or is at root state
-            return if (activePaneRole != PaneRole.Primary) {
-                // Non-PRIMARY pane at root: clear this pane's stack and switch to PRIMARY
-                // This ensures back navigation properly clears the secondary pane
-                var newState = clearPaneStack(root, paneNode.key, activePaneRole)
-                newState = switchActivePane(newState, paneNode.key, PaneRole.Primary)
-                PopResult.Popped(newState)
-            } else {
-                PopResult.PaneEmpty(activePaneRole)
-            }
-        }
-
-        // Pop from the active stack
-        val newChildren = activeStack.children.dropLast(1)
-        val newStack = activeStack.copy(children = newChildren)
-        val newState = replaceNode(root, activeStack.key, newStack)
-        return PopResult.Popped(newState)
-    }
-    
-    /**
-     * Clears a pane's stack, removing all children.
-     * 
-     * @param root The root NavNode
-     * @param paneNodeKey Key of the PaneNode
-     * @param role The pane role to clear
-     * @return New tree with the pane's stack cleared
-     */
-    private fun clearPaneStack(root: NavNode, paneNodeKey: String, role: PaneRole): NavNode {
-        val paneNode = root.findByKey(paneNodeKey) as? PaneNode ?: return root
-        val paneConfig = paneNode.paneConfigurations[role] ?: return root
-        val stackNode = paneConfig.content as? StackNode ?: return root
-        
-        // Clear the stack by removing all children
-        val clearedStack = stackNode.copy(children = emptyList())
-        val newConfig = paneConfig.copy(content = clearedStack)
-        val newConfigurations = paneNode.paneConfigurations + (role to newConfig)
-        val newPaneNode = paneNode.copy(paneConfigurations = newConfigurations)
-        return replaceNode(root, paneNodeKey, newPaneNode)
-    }
+    fun popPaneAdaptive(root: NavNode, isCompact: Boolean): PopResult =
+        PaneOperations.popPaneAdaptive(root, isCompact)
 
     /**
      * Sets or updates the configuration for a pane role.
      *
-     * @param root The root NavNode of the navigation tree
-     * @param nodeKey Key of the PaneNode to mutate
-     * @param role Pane role to configure
-     * @param config New pane configuration
-     * @return New tree with configuration updated
-     * @throws IllegalArgumentException if nodeKey not found
+     * @see PaneOperations.setPaneConfiguration
      */
     fun setPaneConfiguration(
         root: NavNode,
         nodeKey: String,
         role: PaneRole,
         config: PaneConfiguration
-    ): NavNode {
-        val paneNode = root.findByKey(nodeKey) as? PaneNode
-            ?: throw IllegalArgumentException("PaneNode with key '$nodeKey' not found")
-
-        val newConfigurations = paneNode.paneConfigurations + (role to config)
-        val newPaneNode = paneNode.copy(paneConfigurations = newConfigurations)
-        return replaceNode(root, nodeKey, newPaneNode)
-    }
+    ): NavNode = PaneOperations.setPaneConfiguration(root, nodeKey, role, config)
 
     /**
      * Removes a pane configuration.
      *
-     * @param root The root NavNode of the navigation tree
-     * @param nodeKey Key of the PaneNode to mutate
-     * @param role Pane role to remove (cannot be Primary)
-     * @return New tree with configuration removed
-     * @throws IllegalArgumentException if trying to remove Primary pane or nodeKey not found
+     * @see PaneOperations.removePaneConfiguration
      */
     fun removePaneConfiguration(
         root: NavNode,
         nodeKey: String,
         role: PaneRole
-    ): NavNode {
-        require(role != PaneRole.Primary) {
-            "Cannot remove Primary pane - it is required"
-        }
-
-        val paneNode = root.findByKey(nodeKey) as? PaneNode
-            ?: throw IllegalArgumentException("PaneNode with key '$nodeKey' not found")
-
-        val newConfigurations = paneNode.paneConfigurations - role
-
-        // If active role is being removed, switch to Primary
-        val newActiveRole = if (paneNode.activePaneRole == role) {
-            PaneRole.Primary
-        } else {
-            paneNode.activePaneRole
-        }
-
-        val newPaneNode = paneNode.copy(
-            paneConfigurations = newConfigurations,
-            activePaneRole = newActiveRole
-        )
-        return replaceNode(root, nodeKey, newPaneNode)
-    }
+    ): NavNode = PaneOperations.removePaneConfiguration(root, nodeKey, role)
 
     // =========================================================================
-    // UTILITY OPERATIONS
+    // UTILITY OPERATIONS (delegate to TreeNodeOperations)
     // =========================================================================
 
     /**
      * Replace a node in the tree by key.
      *
-     * Performs a depth-first search for the node with [targetKey], then
-     * rebuilds the tree path with [newNode] in place of the old node.
-     * Unchanged subtrees are reused by reference (structural sharing).
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param targetKey Key of the node to replace
-     * @param newNode The replacement node
-     * @return New tree with the node replaced
-     * @throws IllegalArgumentException if targetKey not found
+     * @see TreeNodeOperations.replaceNode
      */
-    fun replaceNode(root: NavNode, targetKey: String, newNode: NavNode): NavNode {
-        if (root.key == targetKey) return newNode
-
-        return when (root) {
-            is ScreenNode -> {
-                throw IllegalArgumentException("Node with key '$targetKey' not found")
-            }
-
-            is StackNode -> {
-                val newChildren = root.children.map { child ->
-                    if (child.key == targetKey) newNode
-                    else if (child.findByKey(targetKey) != null) replaceNode(
-                        child,
-                        targetKey,
-                        newNode
-                    )
-                    else child
-                }
-                if (newChildren == root.children) {
-                    throw IllegalArgumentException("Node with key '$targetKey' not found")
-                }
-                root.copy(children = newChildren)
-            }
-
-            is TabNode -> {
-                val newStacks = root.stacks.map { stack ->
-                    if (stack.key == targetKey) newNode as StackNode
-                    else if (stack.findByKey(targetKey) != null) {
-                        replaceNode(stack, targetKey, newNode) as StackNode
-                    } else stack
-                }
-                if (newStacks == root.stacks) {
-                    throw IllegalArgumentException("Node with key '$targetKey' not found")
-                }
-                root.copy(stacks = newStacks)
-            }
-
-            is PaneNode -> {
-                val newConfigurations = root.paneConfigurations.mapValues { (_, config) ->
-                    if (config.content.key == targetKey) {
-                        config.copy(content = newNode)
-                    } else if (config.content.findByKey(targetKey) != null) {
-                        config.copy(content = replaceNode(config.content, targetKey, newNode))
-                    } else {
-                        config
-                    }
-                }
-                if (newConfigurations == root.paneConfigurations) {
-                    throw IllegalArgumentException("Node with key '$targetKey' not found")
-                }
-                root.copy(paneConfigurations = newConfigurations)
-            }
-        }
-    }
+    fun replaceNode(root: NavNode, targetKey: String, newNode: NavNode): NavNode =
+        TreeNodeOperations.replaceNode(root, targetKey, newNode)
 
     /**
      * Remove a node from the tree by key.
      *
-     * The behavior depends on the parent node type:
-     * - From StackNode: Removes child from children list
-     * - From TabNode: Cannot remove stacks (throws exception)
-     * - From PaneNode: Cannot remove panes (throws exception)
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param targetKey Key of the node to remove
-     * @return New tree with the node removed, or null if root itself would be removed
-     * @throws IllegalArgumentException if targetKey not found or removal not allowed
+     * @see TreeNodeOperations.removeNode
      */
-    fun removeNode(root: NavNode, targetKey: String): NavNode? {
-        // Cannot remove the root
-        if (root.key == targetKey) return null
+    fun removeNode(root: NavNode, targetKey: String): NavNode? =
+        TreeNodeOperations.removeNode(root, targetKey)
 
-        return when (root) {
-            is ScreenNode -> {
-                throw IllegalArgumentException("Node with key '$targetKey' not found")
-            }
-
-            is StackNode -> {
-                // Check if any child has this key
-                val childIndex = root.children.indexOfFirst { it.key == targetKey }
-                if (childIndex != -1) {
-                    val newChildren = root.children.toMutableList().apply { removeAt(childIndex) }
-                    return root.copy(children = newChildren)
-                }
-
-                // Search recursively
-                val newChildren = root.children.map { child ->
-                    if (child.findByKey(targetKey) != null) {
-                        removeNode(child, targetKey)
-                            ?: throw IllegalArgumentException("Cannot remove root of subtree '$targetKey'")
-                    } else child
-                }
-                if (newChildren == root.children) {
-                    throw IllegalArgumentException("Node with key '$targetKey' not found")
-                }
-                root.copy(children = newChildren)
-            }
-
-            is TabNode -> {
-                // Cannot remove stacks directly from TabNode
-                if (root.stacks.any { it.key == targetKey }) {
-                    throw IllegalArgumentException("Cannot remove stack '$targetKey' from TabNode - use switchTab instead")
-                }
-
-                val newStacks = root.stacks.map { stack ->
-                    if (stack.findByKey(targetKey) != null) {
-                        removeNode(stack, targetKey) as? StackNode
-                            ?: throw IllegalArgumentException("Cannot remove root of subtree '$targetKey'")
-                    } else stack
-                }
-                if (newStacks == root.stacks) {
-                    throw IllegalArgumentException("Node with key '$targetKey' not found")
-                }
-                root.copy(stacks = newStacks)
-            }
-
-            is PaneNode -> {
-                // Cannot remove pane configurations directly
-                if (root.paneConfigurations.values.any { it.content.key == targetKey }) {
-                    throw IllegalArgumentException("Cannot remove pane content '$targetKey' directly - use removePaneConfiguration instead")
-                }
-
-                val newConfigurations = root.paneConfigurations.mapValues { (_, config) ->
-                    if (config.content.findByKey(targetKey) != null) {
-                        val newContent = removeNode(config.content, targetKey)
-                            ?: throw IllegalArgumentException("Cannot remove root of subtree '$targetKey'")
-                        config.copy(content = newContent)
-                    } else {
-                        config
-                    }
-                }
-                if (newConfigurations == root.paneConfigurations) {
-                    throw IllegalArgumentException("Node with key '$targetKey' not found")
-                }
-                root.copy(paneConfigurations = newConfigurations)
-            }
-        }
-    }
-
-    /**
-     * Clear a stack and push a single screen.
-     *
-     * Replaces all content in the deepest active stack with a single screen.
-     * Useful for "navigate and clear" patterns like returning to a home screen.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param destination The destination to navigate to
-     * @param generateKey Function to generate unique keys for new nodes
-     * @return New tree with cleared stack containing only the new screen
-     * @throws IllegalStateException if no active stack found
-     */
-    @OptIn(ExperimentalUuidApi::class)
-    fun clearAndPush(
-        root: NavNode,
-        destination: NavDestination,
-        generateKey: () -> String = { Uuid.random().toString().take(8) }
-    ): NavNode {
-        val targetStack = root.activeStack()
-            ?: throw IllegalStateException("No active stack found in tree")
-
-        val newScreen = ScreenNode(
-            key = generateKey(),
-            parentKey = targetStack.key,
-            destination = destination
-        )
-
-        val newStack = targetStack.copy(children = listOf(newScreen))
-        return replaceNode(root, targetStack.key, newStack)
-    }
-
-    /**
-     * Clear a specific stack and push a single screen.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param stackKey Key of the stack to clear
-     * @param destination The destination to navigate to
-     * @param generateKey Function to generate unique keys for new nodes
-     * @return New tree with cleared stack containing only the new screen
-     * @throws IllegalArgumentException if stackKey not found or not a StackNode
-     */
-    @OptIn(ExperimentalUuidApi::class)
-    fun clearStackAndPush(
-        root: NavNode,
-        stackKey: String,
-        destination: NavDestination,
-        generateKey: () -> String = { Uuid.random().toString().take(8) }
-    ): NavNode {
-        val targetNode = root.findByKey(stackKey)
-            ?: throw IllegalArgumentException("Node with key '$stackKey' not found")
-
-        require(targetNode is StackNode) {
-            "Node '$stackKey' is ${targetNode::class.simpleName}, expected StackNode"
-        }
-
-        val newScreen = ScreenNode(
-            key = generateKey(),
-            parentKey = stackKey,
-            destination = destination
-        )
-
-        val newStack = targetNode.copy(children = listOf(newScreen))
-        return replaceNode(root, stackKey, newStack)
-    }
-
-    /**
-     * Replace the currently active screen with a new destination.
-     *
-     * Replaces the top screen in the deepest active stack without adding to
-     * the back stack. The stack size remains the same.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param destination The destination to replace with
-     * @param generateKey Function to generate unique keys for new nodes
-     * @return New tree with the top screen replaced
-     * @throws IllegalStateException if no active stack or stack is empty
-     */
-    @OptIn(ExperimentalUuidApi::class)
-    fun replaceCurrent(
-        root: NavNode,
-        destination: NavDestination,
-        generateKey: () -> String = { Uuid.random().toString().take(8) }
-    ): NavNode {
-        val targetStack = root.activeStack()
-            ?: throw IllegalStateException("No active stack found in tree")
-
-        require(targetStack.children.isNotEmpty()) {
-            "Cannot replace in empty stack"
-        }
-
-        val newScreen = ScreenNode(
-            key = generateKey(),
-            parentKey = targetStack.key,
-            destination = destination
-        )
-
-        val newChildren = targetStack.children.dropLast(1) + newScreen
-        val newStack = targetStack.copy(children = newChildren)
-        return replaceNode(root, targetStack.key, newStack)
-    }
-
-    /**
-     * Push multiple destinations at once.
-     *
-     * Appends all destinations to the deepest active stack in order.
-     * More efficient than calling push multiple times as the tree is
-     * only rebuilt once.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @param destinations The destinations to push (in order, first = bottom)
-     * @param generateKey Function to generate unique keys for new nodes
-     * @return New tree with all destinations pushed
-     * @throws IllegalStateException if no active stack found
-     */
-    @OptIn(ExperimentalUuidApi::class)
-    fun pushAll(
-        root: NavNode,
-        destinations: List<NavDestination>,
-        generateKey: () -> String = { Uuid.random().toString().take(8) }
-    ): NavNode {
-        if (destinations.isEmpty()) return root
-
-        val targetStack = root.activeStack()
-            ?: throw IllegalStateException("No active stack found in tree")
-
-        val newScreens = destinations.map { destination ->
-            ScreenNode(
-                key = generateKey(),
-                parentKey = targetStack.key,
-                destination = destination
-            )
-        }
-
-        val newStack = targetStack.copy(children = targetStack.children + newScreens)
-        return replaceNode(root, targetStack.key, newStack)
-    }
+    // =========================================================================
+    // BACK OPERATIONS (delegate to BackOperations)
+    // =========================================================================
 
     /**
      * Check if back navigation is possible from the current state.
      *
-     * Returns true if there is at least one screen that can be popped
-     * from any active stack in the tree.
-     *
-     * @param root The root NavNode of the navigation tree
-     * @return true if back navigation is possible
+     * @see BackOperations.canGoBack
      */
-    fun canGoBack(root: NavNode): Boolean {
-        val activeStack = root.activeStack() ?: return false
-        return activeStack.canGoBack
-    }
+    fun canGoBack(root: NavNode): Boolean = BackOperations.canGoBack(root)
 
     /**
      * Get the current active destination.
      *
-     * @param root The root NavNode of the navigation tree
-     * @return The current active Destination, or null if tree is empty
+     * @see BackOperations.currentDestination
      */
-    fun currentDestination(root: NavNode): NavDestination? {
-        return root.activeLeaf()?.destination
-    }
-
-    // =========================================================================
-    // TREE-AWARE BACK HANDLING
-    // =========================================================================
+    fun currentDestination(root: NavNode): NavDestination? =
+        BackOperations.currentDestination(root)
 
     /**
      * Pop with intelligent tab handling.
      *
-     * Handles back navigation with proper tab behavior:
-     * 1. If active tab's stack has > 1 items → pop from stack
-     * 2. If active tab's stack is at root AND not initial tab → switch to initial tab
-     * 3. If on initial tab at root → continue to next stack level
-     *
-     * @param root The root NavNode
-     * @param isCompact Whether in compact mode (single pane visible). Default true.
-     *                  In expanded mode, panes are popped entirely rather than switching.
-     * @return BackResult indicating the outcome
+     * @see BackOperations.popWithTabBehavior
      */
-    fun popWithTabBehavior(root: NavNode, isCompact: Boolean = true): BackResult {
-        val activeStack = root.activeStack() ?: return BackResult.CannotHandle
-
-        // Case 1: Stack has items to pop
-        if (activeStack.canGoBack) {
-            val newState = pop(root) ?: return BackResult.CannotHandle
-            return BackResult.Handled(newState)
-        }
-
-        // Find the parent tab node if any
-        val parentKey = activeStack.parentKey ?: return handleRootStackBack(root, activeStack)
-        val parent = root.findByKey(parentKey)
-
-        return when (parent) {
-            is TabNode -> handleTabBack(root, parent, activeStack)
-            is StackNode -> handleNestedStackBack(root, parent, activeStack)
-            is PaneNode -> handlePaneBack(root, parent, activeStack, isCompact)
-            else -> BackResult.CannotHandle
-        }
-    }
-
-    /**
-     * Handle back when the active stack is a root stack.
-     */
-    private fun handleRootStackBack(root: NavNode, activeStack: StackNode): BackResult {
-        // Root stack at minimum size - delegate to system
-        return if (activeStack.children.size <= 1) {
-            BackResult.DelegateToSystem
-        } else {
-            val newState = pop(root) ?: return BackResult.CannotHandle
-            BackResult.Handled(newState)
-        }
-    }
-
-    /**
-     * Handle back when active stack is inside a TabNode.
-     *
-     * Simplified behavior:
-     * - If active tab's stack has only 1 child: pop entire TabNode (regardless of which tab)
-     * - If parent also has only one child: cascade further up the tree
-     *
-     * Note: This does NOT switch tabs on back - it pops the entire TabNode.
-     */
-    private fun handleTabBack(root: NavNode, tabNode: TabNode, activeStack: NavNode): BackResult {
-        // Active tab's stack has only 1 child → try to pop the entire TabNode
-        val tabParentKey = tabNode.parentKey
-        if (tabParentKey == null) {
-            // TabNode is root - delegate to system
-            return BackResult.DelegateToSystem
-        }
-
-        // TabNode has a parent - try to pop from it
-        return when (val tabParent = root.findByKey(tabParentKey)) {
-            is StackNode -> {
-                if (tabParent.children.size > 1) {
-                    // Parent stack has multiple children - can pop TabNode
-                    val newState = removeNode(root, tabNode.key)
-                    if (newState != null) BackResult.Handled(newState) else BackResult.CannotHandle
-                } else if (tabParent.parentKey == null) {
-                    // Parent is root stack with only TabNode - delegate to system
-                    BackResult.DelegateToSystem
-                } else {
-                    // CASCADE: Parent stack has only TabNode - try to pop parent from grandparent
-                    val grandparentKey = tabParent.parentKey
-                    val grandparent = root.findByKey(grandparentKey)
-
-                    when (grandparent) {
-                        is StackNode -> handleNestedStackBack(root, grandparent, tabParent)
-                        is TabNode -> handleTabBack(root, grandparent, tabParent)
-                        is PaneNode -> handlePaneBack(root, grandparent, tabParent, isCompact = true)
-                        else -> BackResult.DelegateToSystem
-                    }
-                }
-            }
-
-            is TabNode -> {
-                // TabNode inside another TabNode (edge case)
-                // Treat parent TabNode as if we're on its stack
-                handleTabBack(root, tabParent, tabNode.activeStack)
-            }
-
-            else -> BackResult.DelegateToSystem
-        }
-    }
-
-    /**
-     * Handle back when active stack is nested inside another stack.
-     *
-     * Cascade behavior:
-     * - If parent can pop child (size > 1): pop child
-     * - If parent is root: delegate to system
-     * - If parent also has only 1 child: cascade to grandparent
-     */
-    private fun handleNestedStackBack(
-        root: NavNode,
-        parentStack: StackNode,
-        childStack: StackNode
-    ): BackResult {
-        return if (parentStack.children.size > 1) {
-            // Parent has multiple children - can remove the child stack
-            val newState = removeNode(root, childStack.key)
-            if (newState != null) BackResult.Handled(newState) else BackResult.CannotHandle
-        } else if (parentStack.parentKey == null) {
-            // Parent is root with only one child - delegate to system
-            BackResult.DelegateToSystem
-        } else {
-            // Parent has only one child and is not root - CASCADE UP
-            // Try to pop the parent stack from its grandparent
-            val grandparentKey = parentStack.parentKey
-            val grandparent = root.findByKey(grandparentKey)
-
-            when (grandparent) {
-                is StackNode -> handleNestedStackBack(root, grandparent, parentStack)
-                is TabNode -> handleTabBack(root, grandparent, parentStack)
-                is PaneNode -> handlePaneBack(root, grandparent, parentStack, isCompact = true)
-                else -> BackResult.DelegateToSystem
-            }
-        }
-    }
-
-    /**
-     * Handle back when active stack is inside a PaneNode.
-     *
-     * Behavior depends on window size:
-     * - In compact mode: use pane back behavior (switch panes, pop within panes)
-     * - In expanded mode: always pop the entire PaneNode (back exits the pane view)
-     *
-     * Cascade behavior:
-     * - If PaneNode is root: delegate to system
-     * - If PaneNode's parent can pop it: pop PaneNode
-     * - If parent also has only one child: cascade further up the tree
-     * 
-     * @param isCompact Whether in compact/single-pane mode
-     */
-    private fun handlePaneBack(
-        root: NavNode,
-        paneNode: PaneNode,
-        activeStack: NavNode,
-        isCompact: Boolean
-    ): BackResult {
-        // In expanded mode, always pop the entire PaneNode
-        // Back should exit the pane view, not navigate within it
-        if (!isCompact) {
-            return popEntirePaneNode(root, paneNode)
-        }
-        
-        // In compact mode, use pane behavior (switch panes, pop within panes)
-        return when (val result = popWithPaneBehavior(root)) {
-            is PopResult.Popped -> BackResult.Handled(result.newState)
-            is PopResult.CannotPop, is PopResult.PaneEmpty -> {
-                // Pane handling exhausted - pop entire PaneNode
-                popEntirePaneNode(root, paneNode)
-            }
-            is PopResult.RequiresScaffoldChange -> BackResult.CannotHandle
-        }
-    }
-    
-    /**
-     * Pop the entire PaneNode from its parent.
-     */
-    private fun popEntirePaneNode(root: NavNode, paneNode: PaneNode): BackResult {
-        val paneParentKey = paneNode.parentKey
-        if (paneParentKey == null) {
-            return BackResult.DelegateToSystem
-        }
-
-        // Try to pop PaneNode from its parent
-        val paneParent = root.findByKey(paneParentKey)
-        return when (paneParent) {
-            is StackNode -> {
-                if (paneParent.children.size > 1) {
-                    val newState = removeNode(root, paneNode.key)
-                    if (newState != null) BackResult.Handled(newState) else BackResult.CannotHandle
-                } else if (paneParent.parentKey == null) {
-                    BackResult.DelegateToSystem
-                } else {
-                    // Continue cascading
-                    val grandparentKey = paneParent.parentKey
-                    val grandparent = root.findByKey(grandparentKey)
-                    when (grandparent) {
-                        is StackNode -> handleNestedStackBack(root, grandparent, paneParent)
-                        is TabNode -> handleTabBack(root, grandparent, paneParent)
-                        is PaneNode -> handlePaneBack(root, grandparent, paneParent, true) // compact mode for cascade
-                        else -> BackResult.DelegateToSystem
-                    }
-                }
-            }
-
-            is TabNode -> {
-                val activeStack = paneNode.activePaneContent?.activeStack()
-                if (activeStack != null) {
-                    handleTabBack(root, paneParent, activeStack)
-                } else {
-                    BackResult.DelegateToSystem
-                }
-            }
-            is PaneNode -> {
-                val activeStack = paneNode.activePaneContent?.activeStack()
-                if (activeStack != null) {
-                    handlePaneBack(root, paneParent, activeStack, true) // compact mode for cascade
-                } else {
-                    BackResult.DelegateToSystem
-                }
-            }
-            else -> BackResult.DelegateToSystem
-        }
-    }
+    fun popWithTabBehavior(root: NavNode, isCompact: Boolean = true): BackResult =
+        BackOperations.popWithTabBehavior(root, isCompact)
 
     /**
      * Check if back navigation is possible, considering root constraints.
      *
-     * Unlike [canGoBack], this method considers:
-     * - Root stack must keep at least one item (would delegate to system)
-     * - Tab switching as an alternative to popping
-     * - Cascade back: removing TabNode from parent when on initial tab
-     *
-     * @param root The root NavNode
-     * @return true if the navigation system can handle back (not delegated to system)
+     * @see BackOperations.canHandleBackNavigation
      */
-    fun canHandleBackNavigation(root: NavNode): Boolean {
-        val activeStack = root.activeStack() ?: return false
-
-        // Can pop from active stack
-        if (activeStack.canGoBack) return true
-
-        // Check for tab switch opportunity or cascade back
-        val parentKey = activeStack.parentKey ?: return false
-        val parent = root.findByKey(parentKey)
-
-        return when (parent) {
-            is TabNode -> {
-                // TabNode can be popped if its parent stack has multiple children
-                val tabParentKey = parent.parentKey ?: return false
-                val tabParent = root.findByKey(tabParentKey)
-                (tabParent as? StackNode)?.children?.size?.let { it > 1 } ?: false
-            }
-
-            is StackNode -> parent.canGoBack
-
-            is PaneNode -> {
-                // Check if any pane's stack can go back
-                val anyPaneCanGoBack = parent.paneConfigurations.values.any {
-                    it.content.activeStack()?.canGoBack == true
-                }
-                if (anyPaneCanGoBack) return true
-
-                // If all panes are at root, check if PaneNode itself can be popped
-                val paneParentKey = parent.parentKey ?: return false
-                val paneParent = root.findByKey(paneParentKey)
-                (paneParent as? StackNode)?.children?.size?.let { it > 1 } ?: false
-            }
-
-            else -> false
-        }
-    }
-
+    fun canHandleBackNavigation(root: NavNode): Boolean =
+        BackOperations.canHandleBackNavigation(root)
 }

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/config/PopBehavior.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/config/PopBehavior.kt
@@ -1,0 +1,18 @@
+package com.jermey.quo.vadis.core.navigation.tree.config
+
+/**
+ * Configures behavior when a StackNode becomes empty after pop.
+ */
+enum class PopBehavior {
+    /**
+     * Remove the empty stack from parent (cascading pop).
+     * This continues popping until a non-empty container is found.
+     */
+    CASCADE,
+
+    /**
+     * Preserve the empty stack in place.
+     * The stack remains but with no children.
+     */
+    PRESERVE_EMPTY
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/operations/BackOperations.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/operations/BackOperations.kt
@@ -1,0 +1,315 @@
+package com.jermey.quo.vadis.core.navigation.tree.operations
+
+import com.jermey.quo.vadis.core.navigation.NavDestination
+import com.jermey.quo.vadis.core.navigation.NavNode
+import com.jermey.quo.vadis.core.navigation.PaneNode
+import com.jermey.quo.vadis.core.navigation.StackNode
+import com.jermey.quo.vadis.core.navigation.TabNode
+import com.jermey.quo.vadis.core.navigation.activeLeaf
+import com.jermey.quo.vadis.core.navigation.activeStack
+import com.jermey.quo.vadis.core.navigation.findByKey
+import com.jermey.quo.vadis.core.navigation.tree.operations.PaneOperations.popWithPaneBehavior
+import com.jermey.quo.vadis.core.navigation.tree.operations.PopOperations.pop
+import com.jermey.quo.vadis.core.navigation.tree.operations.TreeNodeOperations.removeNode
+import com.jermey.quo.vadis.core.navigation.tree.result.BackResult
+import com.jermey.quo.vadis.core.navigation.tree.result.PopResult
+
+/**
+ * Tree-aware back navigation operations.
+ * 
+ * Handles back navigation with awareness of the full tree structure:
+ * - Pop with tab behavior (return to first tab before exiting)
+ * - Nested stack handling
+ * - Pane back behavior
+ * - Query whether back navigation is possible
+ */
+object BackOperations {
+
+    /**
+     * Check if back navigation is possible from the current state.
+     *
+     * Returns true if there is at least one screen that can be popped
+     * from any active stack in the tree.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @return true if back navigation is possible
+     */
+    fun canGoBack(root: NavNode): Boolean {
+        val activeStack = root.activeStack() ?: return false
+        return activeStack.canGoBack
+    }
+
+    /**
+     * Get the current active destination.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @return The current active Destination, or null if tree is empty
+     */
+    fun currentDestination(root: NavNode): NavDestination? {
+        return root.activeLeaf()?.destination
+    }
+
+    /**
+     * Pop with intelligent tab handling.
+     *
+     * Handles back navigation with proper tab behavior:
+     * 1. If active tab's stack has > 1 items → pop from stack
+     * 2. If active tab's stack is at root AND not initial tab → switch to initial tab
+     * 3. If on initial tab at root → continue to next stack level
+     *
+     * @param root The root NavNode
+     * @param isCompact Whether in compact mode (single pane visible). Default true.
+     *                  In expanded mode, panes are popped entirely rather than switching.
+     * @return BackResult indicating the outcome
+     */
+    fun popWithTabBehavior(root: NavNode, isCompact: Boolean = true): BackResult {
+        val activeStack = root.activeStack() ?: return BackResult.CannotHandle
+
+        // Case 1: Stack has items to pop
+        if (activeStack.canGoBack) {
+            val newState = pop(root) ?: return BackResult.CannotHandle
+            return BackResult.Handled(newState)
+        }
+
+        // Find the parent tab node if any
+        val parentKey = activeStack.parentKey ?: return handleRootStackBack(root, activeStack)
+        return when (val parent = root.findByKey(parentKey)) {
+            is TabNode -> handleTabBack(root, parent)
+            is StackNode -> handleNestedStackBack(root, parent, activeStack)
+            is PaneNode -> handlePaneBack(root, parent, isCompact)
+            else -> BackResult.CannotHandle
+        }
+    }
+
+    /**
+     * Check if back navigation is possible, considering root constraints.
+     *
+     * Unlike [canGoBack], this method considers:
+     * - Root stack must keep at least one item (would delegate to system)
+     * - Tab switching as an alternative to popping
+     * - Cascade back: removing TabNode from parent when on initial tab
+     *
+     * @param root The root NavNode
+     * @return true if the navigation system can handle back (not delegated to system)
+     */
+    fun canHandleBackNavigation(root: NavNode): Boolean {
+        val activeStack = root.activeStack() ?: return false
+
+        // Can pop from active stack
+        if (activeStack.canGoBack) return true
+
+        // Check for tab switch opportunity or cascade back
+        val parentKey = activeStack.parentKey ?: return false
+        return when (val parent = root.findByKey(parentKey)) {
+            is TabNode -> {
+                // TabNode can be popped if its parent stack has multiple children
+                val tabParentKey = parent.parentKey ?: return false
+                val tabParent = root.findByKey(tabParentKey)
+                (tabParent as? StackNode)?.children?.size?.let { it > 1 } ?: false
+            }
+
+            is StackNode -> parent.canGoBack
+
+            is PaneNode -> {
+                // Check if any pane's stack can go back
+                val anyPaneCanGoBack = parent.paneConfigurations.values.any {
+                    it.content.activeStack()?.canGoBack == true
+                }
+                if (anyPaneCanGoBack) return true
+
+                // If all panes are at root, check if PaneNode itself can be popped
+                val paneParentKey = parent.parentKey ?: return false
+                val paneParent = root.findByKey(paneParentKey)
+                (paneParent as? StackNode)?.children?.size?.let { it > 1 } ?: false
+            }
+
+            else -> false
+        }
+    }
+
+    /**
+     * Handle back when the active stack is a root stack.
+     */
+    private fun handleRootStackBack(root: NavNode, activeStack: StackNode): BackResult {
+        // Root stack at minimum size - delegate to system
+        return if (activeStack.children.size <= 1) {
+            BackResult.DelegateToSystem
+        } else {
+            val newState = pop(root) ?: return BackResult.CannotHandle
+            BackResult.Handled(newState)
+        }
+    }
+
+    /**
+     * Handle back when active stack is inside a TabNode.
+     *
+     * Simplified behavior:
+     * - If active tab's stack has only 1 child: pop entire TabNode (regardless of which tab)
+     * - If parent also has only one child: cascade further up the tree
+     *
+     * Note: This does NOT switch tabs on back - it pops the entire TabNode.
+     */
+    private fun handleTabBack(root: NavNode, tabNode: TabNode): BackResult {
+        // Active tab's stack has only 1 child → try to pop the entire TabNode
+        val tabParentKey = tabNode.parentKey ?: // TabNode is root - delegate to system
+        return BackResult.DelegateToSystem
+
+        // TabNode has a parent - try to pop from it
+        return when (val tabParent = root.findByKey(tabParentKey)) {
+            is StackNode -> {
+                if (tabParent.children.size > 1) {
+                    // Parent stack has multiple children - can pop TabNode
+                    val newState = removeNode(root, tabNode.key)
+                    if (newState != null) BackResult.Handled(newState) else BackResult.CannotHandle
+                } else if (tabParent.parentKey == null) {
+                    // Parent is root stack with only TabNode - delegate to system
+                    BackResult.DelegateToSystem
+                } else {
+                    // CASCADE: Parent stack has only TabNode - try to pop parent from grandparent
+                    val grandparentKey = tabParent.parentKey
+                    when (val grandparent = root.findByKey(grandparentKey)) {
+                        is StackNode -> handleNestedStackBack(root, grandparent, tabParent)
+                        is TabNode -> handleTabBack(root, grandparent)
+                        is PaneNode -> handlePaneBack(
+                            root,
+                            grandparent,
+                            isCompact = true
+                        )
+
+                        else -> BackResult.DelegateToSystem
+                    }
+                }
+            }
+
+            is TabNode -> {
+                // TabNode inside another TabNode (edge case)
+                // Treat parent TabNode as if we're on its stack
+                handleTabBack(root, tabParent)
+            }
+
+            else -> BackResult.DelegateToSystem
+        }
+    }
+
+    /**
+     * Handle back when active stack is nested inside another stack.
+     *
+     * Cascade behavior:
+     * - If parent can pop child (size > 1): pop child
+     * - If parent is root: delegate to system
+     * - If parent also has only 1 child: cascade to grandparent
+     */
+    private fun handleNestedStackBack(
+        root: NavNode,
+        parentStack: StackNode,
+        childStack: StackNode
+    ): BackResult {
+        return if (parentStack.children.size > 1) {
+            // Parent has multiple children - can remove the child stack
+            val newState = removeNode(root, childStack.key)
+            if (newState != null) BackResult.Handled(newState) else BackResult.CannotHandle
+        } else if (parentStack.parentKey == null) {
+            // Parent is root with only one child - delegate to system
+            BackResult.DelegateToSystem
+        } else {
+            // Parent has only one child and is not root - CASCADE UP
+            // Try to pop the parent stack from its grandparent
+            val grandparentKey = parentStack.parentKey
+            when (val grandparent = root.findByKey(grandparentKey)) {
+                is StackNode -> handleNestedStackBack(root, grandparent, parentStack)
+                is TabNode -> handleTabBack(root, grandparent)
+                is PaneNode -> handlePaneBack(root, grandparent, isCompact = true)
+                else -> BackResult.DelegateToSystem
+            }
+        }
+    }
+
+    /**
+     * Handle back when active stack is inside a PaneNode.
+     *
+     * Behavior depends on window size:
+     * - In compact mode: use pane back behavior (switch panes, pop within panes)
+     * - In expanded mode: always pop the entire PaneNode (back exits the pane view)
+     *
+     * Cascade behavior:
+     * - If PaneNode is root: delegate to system
+     * - If PaneNode's parent can pop it: pop PaneNode
+     * - If parent also has only one child: cascade further up the tree
+     *
+     * @param isCompact Whether in compact/single-pane mode
+     */
+    private fun handlePaneBack(
+        root: NavNode,
+        paneNode: PaneNode,
+        isCompact: Boolean
+    ): BackResult {
+        // In expanded mode, always pop the entire PaneNode
+        // Back should exit the pane view, not navigate within it
+        if (!isCompact) {
+            return popEntirePaneNode(root, paneNode)
+        }
+
+        // In compact mode, use pane behavior (switch panes, pop within panes)
+        return when (val result = popWithPaneBehavior(root)) {
+            is PopResult.Popped -> BackResult.Handled(result.newState)
+            is PopResult.CannotPop, is PopResult.PaneEmpty -> {
+                // Pane handling exhausted - pop entire PaneNode
+                popEntirePaneNode(root, paneNode)
+            }
+
+            is PopResult.RequiresScaffoldChange -> BackResult.CannotHandle
+        }
+    }
+
+    /**
+     * Pop the entire PaneNode from its parent.
+     */
+    private fun popEntirePaneNode(root: NavNode, paneNode: PaneNode): BackResult {
+        val paneParentKey = paneNode.parentKey ?: return BackResult.DelegateToSystem
+
+        // Try to pop PaneNode from its parent
+        return when (val paneParent = root.findByKey(paneParentKey)) {
+            is StackNode -> {
+                if (paneParent.children.size > 1) {
+                    val newState = removeNode(root, paneNode.key)
+                    if (newState != null) BackResult.Handled(newState) else BackResult.CannotHandle
+                } else if (paneParent.parentKey == null) {
+                    BackResult.DelegateToSystem
+                } else {
+                    // Continue cascading
+                    val grandparentKey = paneParent.parentKey
+                    when (val grandparent = root.findByKey(grandparentKey)) {
+                        is StackNode -> handleNestedStackBack(root, grandparent, paneParent)
+                        is TabNode -> handleTabBack(root, grandparent)
+                        is PaneNode -> handlePaneBack(
+                            root,
+                            grandparent,
+                            true
+                        ) // compact mode for cascade
+                        else -> BackResult.DelegateToSystem
+                    }
+                }
+            }
+
+            is TabNode -> {
+                val activeStack = paneNode.activePaneContent?.activeStack()
+                if (activeStack != null) {
+                    handleTabBack(root, paneParent)
+                } else {
+                    BackResult.DelegateToSystem
+                }
+            }
+
+            is PaneNode -> {
+                val activeStack = paneNode.activePaneContent?.activeStack()
+                if (activeStack != null) {
+                    handlePaneBack(root, paneParent, true) // compact mode for cascade
+                } else {
+                    BackResult.DelegateToSystem
+                }
+            }
+
+            else -> BackResult.DelegateToSystem
+        }
+    }
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/operations/PaneOperations.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/operations/PaneOperations.kt
@@ -1,0 +1,421 @@
+package com.jermey.quo.vadis.core.navigation.tree.operations
+
+import com.jermey.quo.vadis.core.navigation.NavDestination
+import com.jermey.quo.vadis.core.navigation.NavNode
+import com.jermey.quo.vadis.core.navigation.PaneNode
+import com.jermey.quo.vadis.core.navigation.ScreenNode
+import com.jermey.quo.vadis.core.navigation.StackNode
+import com.jermey.quo.vadis.core.navigation.activePathToLeaf
+import com.jermey.quo.vadis.core.navigation.activeStack
+import com.jermey.quo.vadis.core.navigation.findByKey
+import com.jermey.quo.vadis.core.navigation.pane.PaneBackBehavior
+import com.jermey.quo.vadis.core.navigation.pane.PaneConfiguration
+import com.jermey.quo.vadis.core.navigation.pane.PaneRole
+import com.jermey.quo.vadis.core.navigation.tree.operations.PopOperations.pop
+import com.jermey.quo.vadis.core.navigation.tree.operations.TreeNodeOperations.replaceNode
+import com.jermey.quo.vadis.core.navigation.tree.result.PopResult
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Pane navigation operations for PaneNode.
+ *
+ * Handles all pane-related navigation:
+ * - Navigate to specific pane with destination
+ * - Switch active pane
+ * - Pop from pane with various behaviors
+ * - Adaptive pop based on layout configuration
+ * - Configure/remove pane configurations
+ */
+object PaneOperations {
+
+    /**
+     * Navigates to a destination within the specified pane role.
+     *
+     * If the pane contains a StackNode (directly or as content), pushes the
+     * destination onto that stack. Optionally switches [PaneNode.activePaneRole]
+     * to the target pane.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param nodeKey Key of the PaneNode to mutate
+     * @param role Target pane role
+     * @param destination Destination to navigate to
+     * @param switchFocus Whether to also set activePaneRole to this role
+     * @param generateKey Function to generate unique keys for new nodes
+     * @return New tree with navigation applied
+     * @throws IllegalArgumentException if nodeKey not found or role not configured
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    fun navigateToPane(
+        root: NavNode,
+        nodeKey: String,
+        role: PaneRole,
+        destination: NavDestination,
+        switchFocus: Boolean = true,
+        generateKey: () -> String = { Uuid.random().toString().take(8) }
+    ): NavNode {
+        val paneNode = root.findByKey(nodeKey) as? PaneNode
+            ?: throw IllegalArgumentException("PaneNode with key '$nodeKey' not found")
+
+        val paneConfig = paneNode.paneConfigurations[role]
+            ?: throw IllegalArgumentException("Pane role $role not configured in PaneNode '$nodeKey'")
+
+        // Find or create a stack in this pane's content
+        val targetStack = when (val paneContent = paneConfig.content) {
+            is StackNode -> paneContent
+            else -> paneContent.activeStack()
+                ?: throw IllegalStateException("No stack found in pane $role content")
+        }
+
+        // Create new screen
+        val newScreen = ScreenNode(
+            key = generateKey(),
+            parentKey = targetStack.key,
+            destination = destination
+        )
+
+        // Update the stack
+        val newStack = targetStack.copy(children = targetStack.children + newScreen)
+
+        // Replace the stack in the tree
+        var result = replaceNode(root, targetStack.key, newStack)
+
+        // Optionally switch focus
+        if (switchFocus && paneNode.activePaneRole != role) {
+            result = switchActivePane(result, nodeKey, role)
+        }
+
+        return result
+    }
+
+    /**
+     * Switches the active pane role without navigating.
+     *
+     * This affects which pane receives subsequent navigation operations
+     * and may influence visibility on compact screens.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param nodeKey Key of the PaneNode to mutate
+     * @param role New active pane role (must exist in paneConfigurations)
+     * @return New tree with active pane switched
+     * @throws IllegalArgumentException if nodeKey not found or role not configured
+     */
+    fun switchActivePane(
+        root: NavNode,
+        nodeKey: String,
+        role: PaneRole
+    ): NavNode {
+        val paneNode = root.findByKey(nodeKey) as? PaneNode
+            ?: throw IllegalArgumentException("PaneNode with key '$nodeKey' not found")
+
+        require(paneNode.paneConfigurations.containsKey(role)) {
+            "Pane role $role not configured in PaneNode '$nodeKey'"
+        }
+
+        if (paneNode.activePaneRole == role) return root
+
+        val newPaneNode = paneNode.copy(activePaneRole = role)
+        return replaceNode(root, nodeKey, newPaneNode)
+    }
+
+    /**
+     * Pops the top entry from the specified pane's stack.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param nodeKey Key of the PaneNode to mutate
+     * @param role Pane role to pop from
+     * @return Updated NavNode, or null if the pane's stack is empty
+     */
+    fun popPane(
+        root: NavNode,
+        nodeKey: String,
+        role: PaneRole
+    ): NavNode? {
+        val paneNode = root.findByKey(nodeKey) as? PaneNode
+            ?: throw IllegalArgumentException("PaneNode with key '$nodeKey' not found")
+
+        val paneConfig = paneNode.paneConfigurations[role]
+            ?: throw IllegalArgumentException("Pane role $role not configured in PaneNode '$nodeKey'")
+
+        // Find the stack in this pane
+        val targetStack = when (val paneContent = paneConfig.content) {
+            is StackNode -> paneContent
+            else -> paneContent.activeStack() ?: return null
+        }
+
+        // Cannot pop from empty stack
+        if (targetStack.isEmpty || targetStack.children.size <= 1) return null
+
+        val newChildren = targetStack.children.dropLast(1)
+        val newStack = targetStack.copy(children = newChildren)
+        return replaceNode(root, targetStack.key, newStack)
+    }
+
+    /**
+     * Pop with respect to PaneBackBehavior.
+     *
+     * This operation considers the [PaneBackBehavior] setting of the active
+     * PaneNode (if any) and returns a [PopResult] indicating what action
+     * was taken or should be taken.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @return PopResult indicating the outcome
+     */
+    fun popWithPaneBehavior(root: NavNode): PopResult {
+        // Find if we're in a PaneNode context
+        val activePath = root.activePathToLeaf()
+        val paneNode = activePath.filterIsInstance<PaneNode>().lastOrNull()
+
+        // If no PaneNode, just do a regular pop
+        if (paneNode == null) {
+            return pop(root)?.let { PopResult.Popped(it) } ?: PopResult.CannotPop
+        }
+
+        val activeStack = root.activeStack() ?: return PopResult.CannotPop
+
+        // If stack has content to pop, pop it
+        if (activeStack.children.size > 1) {
+            return pop(root)?.let { PopResult.Popped(it) } ?: PopResult.CannotPop
+        }
+
+        // Stack would become empty or is at root - apply PaneBackBehavior
+        return when (paneNode.backBehavior) {
+            PaneBackBehavior.PopLatest -> {
+                // Simple pop - if we can't, we can't
+                pop(root)?.let { PopResult.Popped(it) } ?: PopResult.CannotPop
+            }
+
+            PaneBackBehavior.PopUntilScaffoldValueChange -> {
+                // Try to switch to Primary pane if we're in a different pane
+                if (paneNode.activePaneRole != PaneRole.Primary) {
+                    val newRoot = switchActivePane(root, paneNode.key, PaneRole.Primary)
+                    PopResult.Popped(newRoot)
+                } else {
+                    // Already on Primary, renderer needs to handle scaffold change
+                    PopResult.RequiresScaffoldChange
+                }
+            }
+
+            PaneBackBehavior.PopUntilCurrentDestinationChange -> {
+                // Try switching to a different pane with content
+                val alternativePanes = paneNode.configuredRoles
+                    .filter { it != paneNode.activePaneRole }
+                    .filter { role ->
+                        val content = paneNode.paneContent(role)
+                        content?.activeStack()?.children?.isNotEmpty() == true
+                    }
+
+                if (alternativePanes.isNotEmpty()) {
+                    val newRole = alternativePanes.first()
+                    val newRoot = switchActivePane(root, paneNode.key, newRole)
+                    PopResult.Popped(newRoot)
+                } else {
+                    PopResult.PaneEmpty(paneNode.activePaneRole)
+                }
+            }
+
+            PaneBackBehavior.PopUntilContentChange -> {
+                // Pop from any pane that has content
+                val panesWithContent = paneNode.configuredRoles.filter { role ->
+                    val content = paneNode.paneContent(role)
+                    val stack = content?.activeStack()
+                    stack != null && stack.children.size > 1
+                }
+
+                if (panesWithContent.isNotEmpty()) {
+                    // Pop from the first pane with content (preferring active)
+                    val targetRole = if (paneNode.activePaneRole in panesWithContent) {
+                        paneNode.activePaneRole
+                    } else {
+                        panesWithContent.first()
+                    }
+                    val poppedResult = popPane(root, paneNode.key, targetRole)
+                    if (poppedResult != null) {
+                        // After popping, check if the target pane returned to root state
+                        // If so, and it's not PRIMARY, clear the pane and switch to PRIMARY
+                        val updatedPaneNode = poppedResult.findByKey(paneNode.key) as? PaneNode
+                        if (updatedPaneNode != null && targetRole != PaneRole.Primary) {
+                            val targetStack = updatedPaneNode.paneContent(targetRole)?.activeStack()
+                            if (targetStack != null && targetStack.children.size <= 1) {
+                                // Target pane is now at root - clear it and switch to PRIMARY
+                                var newState =
+                                    clearPaneStack(poppedResult, paneNode.key, targetRole)
+                                newState =
+                                    switchActivePane(newState, paneNode.key, PaneRole.Primary)
+                                return PopResult.Popped(newState)
+                            }
+                        }
+                        PopResult.Popped(poppedResult)
+                    } else {
+                        PopResult.PaneEmpty(paneNode.activePaneRole)
+                    }
+                } else {
+                    // No panes have content to pop
+                    // If we're on a non-PRIMARY pane, clear it and switch to PRIMARY
+                    if (paneNode.activePaneRole != PaneRole.Primary) {
+                        var newRoot = clearPaneStack(root, paneNode.key, paneNode.activePaneRole)
+                        newRoot = switchActivePane(newRoot, paneNode.key, PaneRole.Primary)
+                        PopResult.Popped(newRoot)
+                    } else {
+                        PopResult.PaneEmpty(paneNode.activePaneRole)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Pop from a pane with awareness of window size.
+     *
+     * In compact mode (single pane visible), back behaves like a simple stack,
+     * ignoring the configured [PaneBackBehavior]. This ensures predictable
+     * back navigation when only one pane is shown.
+     *
+     * In expanded mode (multiple panes visible), the configured [PaneBackBehavior]
+     * applies, allowing for sophisticated multi-pane back behaviors.
+     *
+     * @param root The root NavNode
+     * @param isCompact Whether currently in compact/single-pane mode
+     * @return PopResult indicating the outcome
+     */
+    fun popPaneAdaptive(root: NavNode, isCompact: Boolean): PopResult {
+        // Find the active pane node if any
+        val activePath = root.activePathToLeaf()
+        val paneNode = activePath.filterIsInstance<PaneNode>().firstOrNull()
+
+        if (paneNode == null) {
+            // No pane node - use standard pop
+            val result = pop(root)
+            return if (result != null) PopResult.Popped(result) else PopResult.CannotPop
+        }
+
+        if (isCompact) {
+            // In compact mode, treat as simple stack
+            // Just pop from the active stack, ignoring pane configuration
+            return popFromActivePane(root, paneNode)
+        }
+
+        // In expanded mode, use configured behavior
+        return popWithPaneBehavior(root)
+    }
+
+    /**
+     * Simple pop from the active pane's stack.
+     *
+     * This is used in compact mode where we want simple stack-like
+     * back navigation regardless of pane configuration.
+     *
+     * @param root The root NavNode
+     * @param paneNode The PaneNode to pop from
+     * @return PopResult indicating the outcome
+     */
+    private fun popFromActivePane(root: NavNode, paneNode: PaneNode): PopResult {
+        val activePaneRole = paneNode.activePaneRole
+        val activeStack = paneNode.activePaneContent?.activeStack()
+
+        if (activeStack == null) {
+            return PopResult.PaneEmpty(activePaneRole)
+        }
+
+        if (activeStack.children.size <= 1) {
+            // Stack would become empty or is at root state
+            return if (activePaneRole != PaneRole.Primary) {
+                // Non-PRIMARY pane at root: clear this pane's stack and switch to PRIMARY
+                // This ensures back navigation properly clears the secondary pane
+                var newState = clearPaneStack(root, paneNode.key, activePaneRole)
+                newState = switchActivePane(newState, paneNode.key, PaneRole.Primary)
+                PopResult.Popped(newState)
+            } else {
+                PopResult.PaneEmpty(activePaneRole)
+            }
+        }
+
+        // Pop from the active stack
+        val newChildren = activeStack.children.dropLast(1)
+        val newStack = activeStack.copy(children = newChildren)
+        val newState = replaceNode(root, activeStack.key, newStack)
+        return PopResult.Popped(newState)
+    }
+
+    /**
+     * Clears a pane's stack, removing all children.
+     *
+     * @param root The root NavNode
+     * @param paneNodeKey Key of the PaneNode
+     * @param role The pane role to clear
+     * @return New tree with the pane's stack cleared
+     */
+    private fun clearPaneStack(root: NavNode, paneNodeKey: String, role: PaneRole): NavNode {
+        val paneNode = root.findByKey(paneNodeKey) as? PaneNode ?: return root
+        val paneConfig = paneNode.paneConfigurations[role] ?: return root
+        val stackNode = paneConfig.content as? StackNode ?: return root
+
+        // Clear the stack by removing all children
+        val clearedStack = stackNode.copy(children = emptyList())
+        val newConfig = paneConfig.copy(content = clearedStack)
+        val newConfigurations = paneNode.paneConfigurations + (role to newConfig)
+        val newPaneNode = paneNode.copy(paneConfigurations = newConfigurations)
+        return replaceNode(root, paneNodeKey, newPaneNode)
+    }
+
+    /**
+     * Sets or updates the configuration for a pane role.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param nodeKey Key of the PaneNode to mutate
+     * @param role Pane role to configure
+     * @param config New pane configuration
+     * @return New tree with configuration updated
+     * @throws IllegalArgumentException if nodeKey not found
+     */
+    fun setPaneConfiguration(
+        root: NavNode,
+        nodeKey: String,
+        role: PaneRole,
+        config: PaneConfiguration
+    ): NavNode {
+        val paneNode = root.findByKey(nodeKey) as? PaneNode
+            ?: throw IllegalArgumentException("PaneNode with key '$nodeKey' not found")
+
+        val newConfigurations = paneNode.paneConfigurations + (role to config)
+        val newPaneNode = paneNode.copy(paneConfigurations = newConfigurations)
+        return replaceNode(root, nodeKey, newPaneNode)
+    }
+
+    /**
+     * Removes a pane configuration.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param nodeKey Key of the PaneNode to mutate
+     * @param role Pane role to remove (cannot be Primary)
+     * @return New tree with configuration removed
+     * @throws IllegalArgumentException if trying to remove Primary pane or nodeKey not found
+     */
+    fun removePaneConfiguration(
+        root: NavNode,
+        nodeKey: String,
+        role: PaneRole
+    ): NavNode {
+        require(role != PaneRole.Primary) {
+            "Cannot remove Primary pane - it is required"
+        }
+
+        val paneNode = root.findByKey(nodeKey) as? PaneNode
+            ?: throw IllegalArgumentException("PaneNode with key '$nodeKey' not found")
+
+        val newConfigurations = paneNode.paneConfigurations - role
+
+        // If active role is being removed, switch to Primary
+        val newActiveRole = if (paneNode.activePaneRole == role) {
+            PaneRole.Primary
+        } else {
+            paneNode.activePaneRole
+        }
+
+        val newPaneNode = paneNode.copy(
+            paneConfigurations = newConfigurations,
+            activePaneRole = newActiveRole
+        )
+        return replaceNode(root, nodeKey, newPaneNode)
+    }
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/operations/PopOperations.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/operations/PopOperations.kt
@@ -1,0 +1,212 @@
+package com.jermey.quo.vadis.core.navigation.tree.operations
+
+import com.jermey.quo.vadis.core.navigation.NavDestination
+import com.jermey.quo.vadis.core.navigation.NavNode
+import com.jermey.quo.vadis.core.navigation.PaneNode
+import com.jermey.quo.vadis.core.navigation.ScreenNode
+import com.jermey.quo.vadis.core.navigation.StackNode
+import com.jermey.quo.vadis.core.navigation.TabNode
+import com.jermey.quo.vadis.core.navigation.activeStack
+import com.jermey.quo.vadis.core.navigation.findByKey
+import com.jermey.quo.vadis.core.navigation.tree.config.PopBehavior
+import com.jermey.quo.vadis.core.navigation.tree.operations.TreeNodeOperations.removeNode
+import com.jermey.quo.vadis.core.navigation.tree.operations.TreeNodeOperations.replaceNode
+
+/**
+ * Pop operations for the navigation tree.
+ *
+ * Handles all backward navigation:
+ * - Simple pop from active stack
+ * - Pop to specific screen by key
+ * - Pop to route pattern
+ * - Pop to destination type
+ */
+object PopOperations {
+
+    /**
+     * Pop the active screen from the deepest active stack.
+     *
+     * Removes the last child from the deepest active StackNode. The [behavior]
+     * parameter controls what happens if the stack becomes empty after popping.
+     *
+     * ## Cascade Behavior
+     *
+     * With [PopBehavior.CASCADE], if popping leaves a stack empty:
+     * - The empty stack is removed from its parent
+     * - This may recursively propagate up the tree
+     * - Returns null if popping would leave the root empty
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * val result = TreeMutator.pop(root, PopBehavior.PRESERVE_EMPTY)
+     * if (result == null) {
+     *     // Cannot pop - at root or tree is empty
+     * }
+     * ```
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param behavior How to handle an empty stack after popping
+     * @return New tree with the top screen popped, or null if cannot pop
+     */
+    fun pop(
+        root: NavNode,
+        behavior: PopBehavior = PopBehavior.PRESERVE_EMPTY
+    ): NavNode? {
+        val targetStack = root.activeStack() ?: return null
+
+        // Cannot pop from empty stack
+        if (targetStack.isEmpty) return null
+
+        // Pop the last child
+        val newChildren = targetStack.children.dropLast(1)
+
+        // Handle empty stack based on behavior
+        if (newChildren.isEmpty()) {
+            return handleEmptyStackPop(root, targetStack, behavior)
+        }
+
+        val newStack = targetStack.copy(children = newChildren)
+        return replaceNode(root, targetStack.key, newStack)
+    }
+
+    /**
+     * Pop all screens from the active stack until the predicate matches.
+     *
+     * Searches from the back (most recent) to the front of the active stack
+     * for a node matching the predicate. All nodes after the match are removed.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param inclusive If true, also removes the matching node
+     * @param predicate Function to identify the target node
+     * @return New tree with nodes popped, or original tree if no match found
+     */
+    fun popTo(
+        root: NavNode,
+        inclusive: Boolean = false,
+        predicate: (NavNode) -> Boolean
+    ): NavNode {
+        val targetStack = root.activeStack() ?: return root
+
+        // Find the index of the matching node (searching from back to front)
+        val matchIndex = targetStack.children.indexOfLast { predicate(it) }
+        if (matchIndex == -1) return root
+
+        // Calculate how many to keep
+        val keepCount = if (inclusive) matchIndex else matchIndex + 1
+        if (keepCount == 0) return root // Would make stack empty
+
+        val newChildren = targetStack.children.take(keepCount)
+        val newStack = targetStack.copy(children = newChildren)
+        return replaceNode(root, targetStack.key, newStack)
+    }
+
+    /**
+     * Pop to a screen with the given key.
+     *
+     * Convenience wrapper around [popTo] that matches by node key.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param targetKey The key of the node to pop to
+     * @param inclusive If true, also removes the matching screen
+     * @return New tree with nodes popped, or original tree if key not found
+     */
+    fun popTo(
+        root: NavNode,
+        targetKey: String,
+        inclusive: Boolean = false
+    ): NavNode {
+        return popTo(root, inclusive) { node ->
+            node.key == targetKey
+        }
+    }
+
+    /**
+     * Pop to a screen with the given route.
+     *
+     * Convenience wrapper around [popTo] that matches by destination route.
+     * Compares the route against [NavDestination.toString] or a route property
+     * if available.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param route The route string to match
+     * @param inclusive If true, also removes the matching screen
+     * @return New tree with nodes popped, or original tree if route not found
+     */
+    fun popToRoute(
+        root: NavNode,
+        route: String,
+        inclusive: Boolean = false
+    ): NavNode {
+        return popTo(root, inclusive) { node ->
+            node is ScreenNode && node.destination.toString() == route
+        }
+    }
+
+    /**
+     * Pop to a screen with destination matching the given type.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param inclusive If true, also removes the matching screen
+     * @return New tree with nodes popped, or original tree if not found
+     */
+    inline fun <reified D : NavDestination> popToDestination(
+        root: NavNode,
+        inclusive: Boolean = false
+    ): NavNode {
+        return popTo(root, inclusive) { node ->
+            node is ScreenNode && node.destination is D
+        }
+    }
+
+    /**
+     * Handle pop when the active stack would become empty.
+     */
+    private fun handleEmptyStackPop(
+        root: NavNode,
+        emptyStack: StackNode,
+        behavior: PopBehavior
+    ): NavNode? {
+        return when (behavior) {
+            PopBehavior.PRESERVE_EMPTY -> {
+                // Just update to empty stack
+                val newStack = emptyStack.copy(children = emptyList())
+                replaceNode(root, emptyStack.key, newStack)
+            }
+
+            PopBehavior.CASCADE -> {
+                // If this is the root, cannot cascade further
+                if (emptyStack.parentKey == null) return null
+
+                // Try to remove this stack from its parent
+                val parent = root.findByKey(emptyStack.parentKey)
+                    ?: return null // Parent not found, cannot cascade
+
+                when (parent) {
+                    is TabNode -> {
+                        // Cannot remove a tab's stack - that would break the tab structure
+                        // Instead, just preserve the empty stack
+                        val newStack = emptyStack.copy(children = emptyList())
+                        replaceNode(root, emptyStack.key, newStack)
+                    }
+
+                    is StackNode -> {
+                        // Remove the empty stack from parent's children
+                        removeNode(root, emptyStack.key)
+                    }
+
+                    is PaneNode -> {
+                        // Cannot remove a pane's content - preserve empty
+                        val newStack = emptyStack.copy(children = emptyList())
+                        replaceNode(root, emptyStack.key, newStack)
+                    }
+
+                    is ScreenNode -> {
+                        // ScreenNode cannot be a parent - this shouldn't happen
+                        null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/operations/PushOperations.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/operations/PushOperations.kt
@@ -1,0 +1,585 @@
+package com.jermey.quo.vadis.core.navigation.tree.operations
+
+import com.jermey.quo.vadis.core.dsl.registry.PaneRoleRegistry
+import com.jermey.quo.vadis.core.dsl.registry.ScopeRegistry
+import com.jermey.quo.vadis.core.navigation.NavDestination
+import com.jermey.quo.vadis.core.navigation.NavNode
+import com.jermey.quo.vadis.core.navigation.PaneNode
+import com.jermey.quo.vadis.core.navigation.ScreenNode
+import com.jermey.quo.vadis.core.navigation.StackNode
+import com.jermey.quo.vadis.core.navigation.TabNode
+import com.jermey.quo.vadis.core.navigation.activePathToLeaf
+import com.jermey.quo.vadis.core.navigation.activeStack
+import com.jermey.quo.vadis.core.navigation.findByKey
+import com.jermey.quo.vadis.core.navigation.pane.PaneRole
+import com.jermey.quo.vadis.core.navigation.tree.operations.TabOperations.switchTab
+import com.jermey.quo.vadis.core.navigation.tree.operations.TreeNodeOperations.replaceNode
+import com.jermey.quo.vadis.core.navigation.tree.result.PushStrategy
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Push operations for the navigation tree.
+ *
+ * Handles all forward navigation:
+ * - Simple push to active stack
+ * - Push to specific stack by key
+ * - Scope-aware push with tab switching
+ * - Pane role routing
+ * - Multi-destination push
+ * - Clear and push patterns
+ */
+object PushOperations {
+
+    @OptIn(ExperimentalUuidApi::class)
+    private val keyGenerator: () -> String = { Uuid.random().toString().take(8) }
+
+    /**
+     * Push a destination onto the deepest active stack.
+     *
+     * Traverses the tree following the active path (active children of TabNodes,
+     * active panes of PaneNodes) until reaching the deepest StackNode, then
+     * appends a new ScreenNode with the given destination.
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * // Given a tree: StackNode -> TabNode -> StackNode(active)
+     * val newTree = TreeMutator.push(root, ProfileDestination)
+     * // ProfileDestination is pushed to the innermost active StackNode
+     * ```
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param destination The destination to navigate to
+     * @param generateKey Function to generate unique keys for new nodes
+     * @return New tree with the destination pushed to the active stack
+     * @throws IllegalStateException if no active stack is found
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    fun push(
+        root: NavNode,
+        destination: NavDestination,
+        generateKey: () -> String = keyGenerator
+    ): NavNode {
+        val targetStack = root.activeStack()
+            ?: throw IllegalStateException("No active stack found in tree")
+
+        val newScreen = ScreenNode(
+            key = generateKey(),
+            parentKey = targetStack.key,
+            destination = destination
+        )
+
+        val newStack = targetStack.copy(
+            children = targetStack.children + newScreen
+        )
+
+        return replaceNode(root, targetStack.key, newStack)
+    }
+
+    /**
+     * Push a destination onto a specific stack identified by key.
+     *
+     * Unlike [push], this allows targeting a specific stack regardless of
+     * whether it's currently active. Useful for pre-populating tab stacks
+     * or background navigation.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param stackKey Key of the target StackNode
+     * @param destination The destination to push
+     * @param generateKey Function to generate unique keys for new nodes
+     * @return New tree with the destination pushed to the specified stack
+     * @throws IllegalArgumentException if stackKey doesn't exist or isn't a StackNode
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    fun pushToStack(
+        root: NavNode,
+        stackKey: String,
+        destination: NavDestination,
+        generateKey: () -> String = keyGenerator
+    ): NavNode {
+        val targetNode = root.findByKey(stackKey)
+            ?: throw IllegalArgumentException("Node with key '$stackKey' not found")
+
+        require(targetNode is StackNode) {
+            "Node '$stackKey' is ${targetNode::class.simpleName}, expected StackNode"
+        }
+
+        val newScreen = ScreenNode(
+            key = generateKey(),
+            parentKey = stackKey,
+            destination = destination
+        )
+
+        val newStack = targetNode.copy(
+            children = targetNode.children + newScreen
+        )
+
+        return replaceNode(root, stackKey, newStack)
+    }
+
+    /**
+     * Push a destination with scope awareness, tab switching, and pane role routing.
+     *
+     * Navigation logic:
+     * 1. First check if destination is in scope (using [scopeRegistry])
+     * 2. For TabNode: check if destination already exists in any tab's stack
+     *    - If found in another tab's stack, switch to that tab instead of pushing
+     * 3. For PaneNode: check if destination has a specific pane role (using [paneRoleRegistry])
+     *    - If destination has a role, push to that pane's stack
+     * 4. If out of scope, delegate to parent stack
+     *
+     * ## Scope Resolution
+     *
+     * The method walks up from the deepest active stack, checking each container
+     * (TabNode/PaneNode) with a [scopeKey][TabNode.scopeKey]. If the destination
+     * is not in that scope (according to [scopeRegistry]), navigation targets
+     * the parent stack instead.
+     *
+     * ## Tab Switching
+     *
+     * When navigating to a destination that already exists in a different tab's
+     * stack (within the same TabNode), the navigator will switch to that tab
+     * instead of creating a duplicate entry.
+     *
+     * ## Pane Role Routing
+     *
+     * When inside a PaneNode context, the [paneRoleRegistry] determines which
+     * pane a destination belongs to. If the destination has a registered role,
+     * navigation pushes to that pane's stack instead of the active stack.
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * // Given: Root -> Stack -> PaneNode(scopeKey="messages") -> Stack(PRIMARY, active)
+     *
+     * // ConversationDetail has paneRole=SECONDARY - pushes to SECONDARY pane's stack
+     * TreeMutator.push(root, ConversationDetail("123"), scopeRegistry, paneRoleRegistry)
+     *
+     * // DetailDestination is NOT in scope - pushes to parent stack (above PaneNode)
+     * TreeMutator.push(root, DetailDestination, scopeRegistry, paneRoleRegistry)
+     * ```
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param destination The destination to navigate to
+     * @param scopeRegistry Registry to check scope membership
+     * @param paneRoleRegistry Registry to determine pane roles for destinations
+     * @param generateKey Function to generate unique keys for new nodes
+     * @return New tree with the destination pushed or tab switched appropriately
+     * @throws IllegalStateException if no suitable stack is found
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    fun push(
+        root: NavNode,
+        destination: NavDestination,
+        scopeRegistry: ScopeRegistry,
+        paneRoleRegistry: PaneRoleRegistry = PaneRoleRegistry.Empty,
+        generateKey: () -> String = keyGenerator
+    ): NavNode {
+        // If no scope registry (or Empty), use the simple push
+        if (scopeRegistry === ScopeRegistry.Empty && paneRoleRegistry === PaneRoleRegistry.Empty) {
+            return push(root, destination, generateKey)
+        }
+
+        return when (val strategy =
+            determinePushStrategy(root, destination, scopeRegistry, paneRoleRegistry)) {
+            is PushStrategy.PushToStack -> {
+                pushToActiveStack(root, strategy.targetStack, destination, generateKey)
+            }
+
+            is PushStrategy.SwitchToTab -> {
+                switchTab(root, strategy.tabNode.key, strategy.tabIndex)
+            }
+
+            is PushStrategy.PushToPaneStack -> {
+                pushToPaneStack(root, strategy.paneNode, strategy.role, destination, generateKey)
+            }
+
+            is PushStrategy.PushOutOfScope -> {
+                pushOutOfScope(root, strategy.parentStack, destination, generateKey)
+            }
+        }
+    }
+
+    /**
+     * Clear a stack and push a single screen.
+     *
+     * Replaces all content in the deepest active stack with a single screen.
+     * Useful for "navigate and clear" patterns like returning to a home screen.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param destination The destination to navigate to
+     * @param generateKey Function to generate unique keys for new nodes
+     * @return New tree with cleared stack containing only the new screen
+     * @throws IllegalStateException if no active stack found
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    fun clearAndPush(
+        root: NavNode,
+        destination: NavDestination,
+        generateKey: () -> String = keyGenerator
+    ): NavNode {
+        val targetStack = root.activeStack()
+            ?: throw IllegalStateException("No active stack found in tree")
+
+        val newScreen = ScreenNode(
+            key = generateKey(),
+            parentKey = targetStack.key,
+            destination = destination
+        )
+
+        val newStack = targetStack.copy(children = listOf(newScreen))
+        return replaceNode(root, targetStack.key, newStack)
+    }
+
+    /**
+     * Clear a specific stack and push a single screen.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param stackKey Key of the stack to clear
+     * @param destination The destination to navigate to
+     * @param generateKey Function to generate unique keys for new nodes
+     * @return New tree with cleared stack containing only the new screen
+     * @throws IllegalArgumentException if stackKey not found or not a StackNode
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    fun clearStackAndPush(
+        root: NavNode,
+        stackKey: String,
+        destination: NavDestination,
+        generateKey: () -> String = keyGenerator
+    ): NavNode {
+        val targetNode = root.findByKey(stackKey)
+            ?: throw IllegalArgumentException("Node with key '$stackKey' not found")
+
+        require(targetNode is StackNode) {
+            "Node '$stackKey' is ${targetNode::class.simpleName}, expected StackNode"
+        }
+
+        val newScreen = ScreenNode(
+            key = generateKey(),
+            parentKey = stackKey,
+            destination = destination
+        )
+
+        val newStack = targetNode.copy(children = listOf(newScreen))
+        return replaceNode(root, stackKey, newStack)
+    }
+
+    /**
+     * Replace the currently active screen with a new destination.
+     *
+     * Replaces the top screen in the deepest active stack without adding to
+     * the back stack. The stack size remains the same.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param destination The destination to replace with
+     * @param generateKey Function to generate unique keys for new nodes
+     * @return New tree with the top screen replaced
+     * @throws IllegalStateException if no active stack or stack is empty
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    fun replaceCurrent(
+        root: NavNode,
+        destination: NavDestination,
+        generateKey: () -> String = keyGenerator
+    ): NavNode {
+        val targetStack = root.activeStack()
+            ?: throw IllegalStateException("No active stack found in tree")
+
+        require(targetStack.children.isNotEmpty()) {
+            "Cannot replace in empty stack"
+        }
+
+        val newScreen = ScreenNode(
+            key = generateKey(),
+            parentKey = targetStack.key,
+            destination = destination
+        )
+
+        val newChildren = targetStack.children.dropLast(1) + newScreen
+        val newStack = targetStack.copy(children = newChildren)
+        return replaceNode(root, targetStack.key, newStack)
+    }
+
+    /**
+     * Push multiple destinations at once.
+     *
+     * Appends all destinations to the deepest active stack in order.
+     * More efficient than calling push multiple times as the tree is
+     * only rebuilt once.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param destinations The destinations to push (in order, first = bottom)
+     * @param generateKey Function to generate unique keys for new nodes
+     * @return New tree with all destinations pushed
+     * @throws IllegalStateException if no active stack found
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    fun pushAll(
+        root: NavNode,
+        destinations: List<NavDestination>,
+        generateKey: () -> String = keyGenerator
+    ): NavNode {
+        if (destinations.isEmpty()) return root
+
+        val targetStack = root.activeStack()
+            ?: throw IllegalStateException("No active stack found in tree")
+
+        val newScreens = destinations.map { destination ->
+            ScreenNode(
+                key = generateKey(),
+                parentKey = targetStack.key,
+                destination = destination
+            )
+        }
+
+        val newStack = targetStack.copy(children = targetStack.children + newScreens)
+        return replaceNode(root, targetStack.key, newStack)
+    }
+
+    // =========================================================================
+    // PRIVATE HELPERS
+    // =========================================================================
+
+    /**
+     * Determines the push strategy for a destination considering scope, tabs, and pane roles.
+     *
+     * Walks up from the deepest active stack, checking each container (TabNode/PaneNode)
+     * to determine how the navigation should be handled.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param destination The destination to check
+     * @param scopeRegistry Registry for scope membership checks
+     * @param paneRoleRegistry Registry for pane role lookups
+     * @return The appropriate PushStrategy for this navigation
+     * @throws IllegalStateException if no valid strategy can be determined
+     */
+    private fun determinePushStrategy(
+        root: NavNode,
+        destination: NavDestination,
+        scopeRegistry: ScopeRegistry,
+        paneRoleRegistry: PaneRoleRegistry = PaneRoleRegistry.Empty
+    ): PushStrategy {
+        val activeStack = root.activeStack()
+            ?: throw IllegalStateException("No active stack found in tree")
+
+        // Walk the active path to find containers
+        val activePath = root.activePathToLeaf()
+
+        // Check containers from deepest to shallowest
+        for (node in activePath.reversed()) {
+            when (node) {
+                is StackNode -> {
+                    // Check if this stack has a scope and if destination is out of scope
+                    val stackScope = node.scopeKey
+                    if (stackScope != null && !scopeRegistry.isInScope(stackScope, destination)) {
+                        // Out of scope - find the stack that contains this StackNode
+                        val parentKey = node.parentKey ?: continue
+                        val parent = root.findByKey(parentKey)
+                        if (parent is StackNode) {
+                            return PushStrategy.PushOutOfScope(parent)
+                        }
+                    }
+                }
+
+                is TabNode -> {
+                    val scopeKey = node.scopeKey
+
+                    // First, check if destination is in scope
+                    if (scopeKey != null && !scopeRegistry.isInScope(scopeKey, destination)) {
+                        // Out of scope - find the stack that contains this TabNode
+                        val parentKey = node.parentKey ?: continue
+                        val parent = root.findByKey(parentKey)
+                        if (parent is StackNode) {
+                            return PushStrategy.PushOutOfScope(parent)
+                        }
+                        continue
+                    }
+
+                    // Destination is in scope - check if it exists in any tab's stack
+                    val existingTabIndex = findTabWithDestination(node, destination)
+                    if (existingTabIndex != null && existingTabIndex != node.activeStackIndex) {
+                        // Destination exists in a different tab - switch to it
+                        return PushStrategy.SwitchToTab(node, existingTabIndex)
+                    }
+
+                    // Destination is in scope but not in another tab - push to active stack
+                    // Continue checking other containers up the tree
+                }
+
+                is PaneNode -> {
+                    val scopeKey = node.scopeKey
+                    if (scopeKey != null && !scopeRegistry.isInScope(scopeKey, destination)) {
+                        // Out of scope - find the stack that contains this PaneNode
+                        val parentKey = node.parentKey ?: continue
+                        val parent = root.findByKey(parentKey)
+                        if (parent is StackNode) {
+                            return PushStrategy.PushOutOfScope(parent)
+                        }
+                        continue
+                    }
+
+                    // Destination is in scope - check if it has a specific pane role
+                    if (scopeKey != null) {
+                        val targetRole = paneRoleRegistry.getPaneRole(scopeKey, destination)
+                        if (targetRole != null && node.paneConfigurations.containsKey(targetRole)) {
+                            // Destination has a registered pane role - push to that pane's stack
+                            return PushStrategy.PushToPaneStack(node, targetRole)
+                        }
+                    }
+                }
+
+                else -> { /* Continue checking */
+                }
+            }
+        }
+
+        // All containers allow this destination, push to deepest active stack
+        return PushStrategy.PushToStack(activeStack)
+    }
+
+    /**
+     * Finds the tab index containing a destination with matching type.
+     *
+     * Searches through all stacks in a TabNode to find one that contains
+     * a ScreenNode with a destination of the same type (class) as the target.
+     *
+     * @param tabNode The TabNode to search within
+     * @param destination The destination to find
+     * @return The tab index if found, null otherwise
+     */
+    private fun findTabWithDestination(tabNode: TabNode, destination: NavDestination): Int? {
+        val destinationClass = destination::class
+        tabNode.stacks.forEachIndexed { index, stack ->
+            // Check if this stack contains a screen with matching destination type
+            val hasDestination = stack.children.any { child ->
+                child is ScreenNode && child.destination::class == destinationClass
+            }
+            if (hasDestination) {
+                return index
+            }
+        }
+        return null
+    }
+
+    /**
+     * Push directly to a specific stack (in-scope case).
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param targetStack The stack to push to
+     * @param destination The destination to push
+     * @param generateKey Function to generate unique keys for new nodes
+     * @return New tree with the destination pushed to the target stack
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    private fun pushToActiveStack(
+        root: NavNode,
+        targetStack: StackNode,
+        destination: NavDestination,
+        generateKey: () -> String
+    ): NavNode {
+        val newScreen = ScreenNode(
+            key = generateKey(),
+            parentKey = targetStack.key,
+            destination = destination
+        )
+
+        val newStack = targetStack.copy(
+            children = targetStack.children + newScreen
+        )
+
+        return replaceNode(root, targetStack.key, newStack)
+    }
+
+    /**
+     * Push a destination outside the current container's scope.
+     *
+     * Creates a new ScreenNode as a child of the parent stack, effectively
+     * navigating "on top of" the container. This preserves the container
+     * (and its state) for back navigation.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param parentStack The stack to push to (parent of the scoped container)
+     * @param destination The destination to push
+     * @param generateKey Function to generate unique keys for new nodes
+     * @return New tree with the destination pushed to the parent stack
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    private fun pushOutOfScope(
+        root: NavNode,
+        parentStack: StackNode,
+        destination: NavDestination,
+        generateKey: () -> String
+    ): NavNode {
+        val screenKey = generateKey()
+
+        // Create new screen as direct child of parent stack
+        val newScreen = ScreenNode(
+            key = screenKey,
+            parentKey = parentStack.key,
+            destination = destination
+        )
+
+        // Add new screen to parent stack's children
+        val updatedParentStack = parentStack.copy(
+            children = parentStack.children + newScreen
+        )
+
+        return replaceNode(root, parentStack.key, updatedParentStack)
+    }
+
+    /**
+     * Push a destination to a specific pane's stack within a PaneNode.
+     *
+     * Finds the stack for the given pane role and pushes the destination there,
+     * optionally switching the active pane to the target role.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param paneNode The PaneNode containing the target pane
+     * @param role The pane role to push to
+     * @param destination The destination to push
+     * @param generateKey Function to generate unique keys for new nodes
+     * @return New tree with the destination pushed to the pane's stack
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    private fun pushToPaneStack(
+        root: NavNode,
+        paneNode: PaneNode,
+        role: PaneRole,
+        destination: NavDestination,
+        generateKey: () -> String
+    ): NavNode {
+        val paneConfig = paneNode.paneConfigurations[role]
+            ?: return root // Role not configured, return unchanged
+
+        val paneStack = paneConfig.content as? StackNode
+            ?: return root // Content is not a StackNode, return unchanged
+
+        // Create new screen node
+        val screenKey = generateKey()
+        val newScreen = ScreenNode(
+            key = screenKey,
+            parentKey = paneStack.key,
+            destination = destination
+        )
+
+        // Update the pane's stack with the new screen
+        val updatedStack = paneStack.copy(
+            children = paneStack.children + newScreen
+        )
+
+        // Update the pane configuration with the new stack
+        val updatedPaneConfig = paneConfig.copy(content = updatedStack)
+        val updatedPaneConfigurations = paneNode.paneConfigurations.toMutableMap()
+        updatedPaneConfigurations[role] = updatedPaneConfig
+
+        // Update the PaneNode with new configurations AND switch active pane
+        val updatedPaneNode = paneNode.copy(
+            paneConfigurations = updatedPaneConfigurations,
+            activePaneRole = role // Switch focus to the target pane
+        )
+
+        return replaceNode(root, paneNode.key, updatedPaneNode)
+    }
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/operations/TabOperations.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/operations/TabOperations.kt
@@ -1,0 +1,68 @@
+package com.jermey.quo.vadis.core.navigation.tree.operations
+
+import com.jermey.quo.vadis.core.navigation.NavNode
+import com.jermey.quo.vadis.core.navigation.TabNode
+import com.jermey.quo.vadis.core.navigation.activePathToLeaf
+import com.jermey.quo.vadis.core.navigation.findByKey
+
+/**
+ * Tab switching operations for TabNode.
+ *
+ * Handles tab navigation within TabNode containers:
+ * - Switch to tab by key and index
+ * - Switch active tab (finds active TabNode automatically)
+ */
+object TabOperations {
+
+    /**
+     * Switch to a different tab in a TabNode.
+     *
+     * Updates the [TabNode.activeStackIndex] to the specified index.
+     * The stacks themselves are unchanged - each tab preserves its history.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param tabNodeKey Key of the TabNode to modify
+     * @param newIndex The tab index to switch to (0-based)
+     * @return New tree with the tab switched
+     * @throws IllegalArgumentException if tabNodeKey not found or not a TabNode
+     * @throws IndexOutOfBoundsException if newIndex is out of bounds
+     */
+    fun switchTab(
+        root: NavNode,
+        tabNodeKey: String,
+        newIndex: Int
+    ): NavNode {
+        val tabNode = root.findByKey(tabNodeKey) as? TabNode
+            ?: throw IllegalArgumentException("TabNode with key '$tabNodeKey' not found")
+
+        require(newIndex in 0 until tabNode.tabCount) {
+            "Tab index $newIndex out of bounds for ${tabNode.tabCount} tabs"
+        }
+
+        if (tabNode.activeStackIndex == newIndex) return root
+
+        val newTabNode = tabNode.copy(activeStackIndex = newIndex)
+        return TreeNodeOperations.replaceNode(root, tabNodeKey, newTabNode)
+    }
+
+    /**
+     * Switch to a different tab in the first TabNode found in the active path.
+     *
+     * Traverses the active path to find the first TabNode, then switches
+     * to the specified tab index. Useful when you don't know or don't want
+     * to specify the exact TabNode key.
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param newIndex The tab index to switch to (0-based)
+     * @return New tree with the tab switched
+     * @throws IllegalStateException if no TabNode found in active path
+     */
+    fun switchActiveTab(root: NavNode, newIndex: Int): NavNode {
+        // Find the first TabNode in the active path
+        val activePath = root.activePathToLeaf()
+        val tabNode = activePath.filterIsInstance<TabNode>().firstOrNull()
+            ?: throw IllegalStateException("No TabNode found in active path")
+
+        return switchTab(root, tabNode.key, newIndex)
+    }
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/operations/TreeNodeOperations.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/operations/TreeNodeOperations.kt
@@ -1,0 +1,177 @@
+package com.jermey.quo.vadis.core.navigation.tree.operations
+
+import com.jermey.quo.vadis.core.navigation.NavNode
+import com.jermey.quo.vadis.core.navigation.PaneNode
+import com.jermey.quo.vadis.core.navigation.ScreenNode
+import com.jermey.quo.vadis.core.navigation.StackNode
+import com.jermey.quo.vadis.core.navigation.TabNode
+import com.jermey.quo.vadis.core.navigation.findByKey
+
+/**
+ * Core tree manipulation utilities.
+ *
+ * Provides foundational operations for modifying the NavNode tree:
+ * - Node replacement (structural sharing for immutability)
+ * - Node removal
+ *
+ * These operations are used internally by specialized operation classes
+ * (PushOperations, PopOperations, etc.) and the TreeMutator façade.
+ */
+object TreeNodeOperations {
+
+    /**
+     * Replace a node in the tree by key.
+     *
+     * Performs a depth-first search for the node with [targetKey], then
+     * rebuilds the tree path with [newNode] in place of the old node.
+     * Unchanged subtrees are reused by reference (structural sharing).
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param targetKey Key of the node to replace
+     * @param newNode The replacement node
+     * @return New tree with the node replaced
+     * @throws IllegalArgumentException if targetKey not found
+     */
+    fun replaceNode(root: NavNode, targetKey: String, newNode: NavNode): NavNode {
+        if (root.key == targetKey) return newNode
+
+        return when (root) {
+            is ScreenNode -> {
+                throw IllegalArgumentException("Node with key '$targetKey' not found")
+            }
+
+            is StackNode -> {
+                val newChildren = root.children.map { child ->
+                    if (child.key == targetKey) newNode
+                    else if (child.findByKey(targetKey) != null) replaceNode(
+                        child,
+                        targetKey,
+                        newNode
+                    )
+                    else child
+                }
+                if (newChildren == root.children) {
+                    throw IllegalArgumentException("Node with key '$targetKey' not found")
+                }
+                root.copy(children = newChildren)
+            }
+
+            is TabNode -> {
+                val newStacks = root.stacks.map { stack ->
+                    if (stack.key == targetKey) newNode as StackNode
+                    else if (stack.findByKey(targetKey) != null) {
+                        replaceNode(stack, targetKey, newNode) as StackNode
+                    } else stack
+                }
+                if (newStacks == root.stacks) {
+                    throw IllegalArgumentException("Node with key '$targetKey' not found")
+                }
+                root.copy(stacks = newStacks)
+            }
+
+            is PaneNode -> {
+                val newConfigurations = root.paneConfigurations.mapValues { (_, config) ->
+                    if (config.content.key == targetKey) {
+                        config.copy(content = newNode)
+                    } else if (config.content.findByKey(targetKey) != null) {
+                        config.copy(content = replaceNode(config.content, targetKey, newNode))
+                    } else {
+                        config
+                    }
+                }
+                if (newConfigurations == root.paneConfigurations) {
+                    throw IllegalArgumentException("Node with key '$targetKey' not found")
+                }
+                root.copy(paneConfigurations = newConfigurations)
+            }
+        }
+    }
+
+    /**
+     * Remove a node from the tree by key.
+     *
+     * The behavior depends on the parent node type:
+     * - From StackNode: Removes child from children list
+     * - From TabNode: Cannot remove stacks (throws exception)
+     * - From PaneNode: Cannot remove panes (throws exception)
+     *
+     * @param root The root NavNode of the navigation tree
+     * @param targetKey Key of the node to remove
+     * @return New tree with the node removed, or null if root itself would be removed
+     * @throws IllegalArgumentException if targetKey not found or removal not allowed
+     */
+    fun removeNode(root: NavNode, targetKey: String): NavNode? {
+        // Cannot remove the root
+        if (root.key == targetKey) return null
+
+        return when (root) {
+            is ScreenNode -> {
+                throw IllegalArgumentException("Node with key '$targetKey' not found")
+            }
+
+            is StackNode -> {
+                // Check if any child has this key
+                val childIndex = root.children.indexOfFirst { it.key == targetKey }
+                if (childIndex != -1) {
+                    val newChildren = root.children.toMutableList().apply { removeAt(childIndex) }
+                    return root.copy(children = newChildren)
+                }
+
+                // Search recursively
+                val newChildren = root.children.map { child ->
+                    if (child.findByKey(targetKey) != null) {
+                        removeNode(child, targetKey)
+                            ?: throw IllegalArgumentException("Cannot remove root of subtree '$targetKey'")
+                    } else child
+                }
+                if (newChildren == root.children) {
+                    throw IllegalArgumentException("Node with key '$targetKey' not found")
+                }
+                root.copy(children = newChildren)
+            }
+
+            is TabNode -> {
+                // Cannot remove stacks directly from TabNode
+                if (root.stacks.any { it.key == targetKey }) {
+                    throw IllegalArgumentException(
+                        "Cannot remove stack '$targetKey' from TabNode - use switchTab instead"
+                    )
+                }
+
+                val newStacks = root.stacks.map { stack ->
+                    if (stack.findByKey(targetKey) != null) {
+                        removeNode(stack, targetKey) as? StackNode
+                            ?: throw IllegalArgumentException("Cannot remove root of subtree '$targetKey'")
+                    } else stack
+                }
+                if (newStacks == root.stacks) {
+                    throw IllegalArgumentException("Node with key '$targetKey' not found")
+                }
+                root.copy(stacks = newStacks)
+            }
+
+            is PaneNode -> {
+                // Cannot remove pane configurations directly
+                if (root.paneConfigurations.values.any { it.content.key == targetKey }) {
+                    throw IllegalArgumentException(
+                        "Cannot remove pane content '$targetKey' directly - use removePaneConfiguration instead"
+                    )
+                }
+
+                val newConfigurations = root.paneConfigurations.mapValues { (_, config) ->
+                    if (config.content.findByKey(targetKey) != null) {
+                        val newContent = removeNode(config.content, targetKey)
+                            ?: throw IllegalArgumentException("Cannot remove root of subtree '$targetKey'")
+                        config.copy(content = newContent)
+                    } else {
+                        config
+                    }
+                }
+                if (newConfigurations == root.paneConfigurations) {
+                    throw IllegalArgumentException("Node with key '$targetKey' not found")
+                }
+                root.copy(paneConfigurations = newConfigurations)
+            }
+        }
+    }
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/result/BackResult.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/result/BackResult.kt
@@ -1,0 +1,17 @@
+package com.jermey.quo.vadis.core.navigation.tree.result
+
+import com.jermey.quo.vadis.core.navigation.NavNode
+
+/**
+ * Result of a tree-aware back operation.
+ */
+sealed class BackResult {
+    /** Back was handled, new tree state returned */
+    data class Handled(val newState: NavNode) : BackResult()
+
+    /** Back should be delegated to system (e.g., close app) */
+    data object DelegateToSystem : BackResult()
+
+    /** Back could not be handled (internal error) */
+    data object CannotHandle : BackResult()
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/result/PopResult.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/result/PopResult.kt
@@ -1,0 +1,21 @@
+package com.jermey.quo.vadis.core.navigation.tree.result
+
+import com.jermey.quo.vadis.core.navigation.NavNode
+import com.jermey.quo.vadis.core.navigation.pane.PaneRole
+
+/**
+ * Result of a pop operation that respects PaneBackBehavior.
+ */
+sealed class PopResult {
+    /** Successfully popped within current pane */
+    data class Popped(val newState: NavNode) : PopResult()
+
+    /** Pane is empty, behavior depends on PaneBackBehavior */
+    data class PaneEmpty(val paneRole: PaneRole) : PopResult()
+
+    /** Cannot pop - would leave tree in invalid state */
+    data object CannotPop : PopResult()
+
+    /** Back behavior requires scaffold/visual change (renderer must handle) */
+    data object RequiresScaffoldChange : PopResult()
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/result/PushStrategy.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/result/PushStrategy.kt
@@ -1,0 +1,26 @@
+package com.jermey.quo.vadis.core.navigation.tree.result
+
+import com.jermey.quo.vadis.core.navigation.PaneNode
+import com.jermey.quo.vadis.core.navigation.StackNode
+import com.jermey.quo.vadis.core.navigation.TabNode
+import com.jermey.quo.vadis.core.navigation.pane.PaneRole
+
+/**
+ * Result of a push operation with tab awareness.
+ *
+ * Used internally to determine how a push should be handled when
+ * navigating within a TabNode context.
+ */
+internal sealed class PushStrategy {
+    /** Push to the specified stack normally */
+    data class PushToStack(val targetStack: StackNode) : PushStrategy()
+
+    /** Switch to an existing tab that contains the destination */
+    data class SwitchToTab(val tabNode: TabNode, val tabIndex: Int) : PushStrategy()
+
+    /** Push to a specific pane's stack within a PaneNode */
+    data class PushToPaneStack(val paneNode: PaneNode, val role: PaneRole) : PushStrategy()
+
+    /** Destination is out of scope - push to parent stack */
+    data class PushOutOfScope(val parentStack: StackNode) : PushStrategy()
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/util/KeyGenerator.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/tree/util/KeyGenerator.kt
@@ -1,0 +1,41 @@
+package com.jermey.quo.vadis.core.navigation.tree.util
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Abstraction for generating unique node keys.
+ *
+ * This functional interface allows for custom key generation strategies,
+ * while providing a sensible default using UUIDs.
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * // Use default UUID-based generator
+ * val key = KeyGenerator.Default.generate()
+ *
+ * // Custom generator
+ * val counter = AtomicInteger(0)
+ * val customGenerator = KeyGenerator { "node-${counter.incrementAndGet()}" }
+ * ```
+ */
+fun interface KeyGenerator {
+    /**
+     * Generates a unique key for a navigation node.
+     *
+     * @return A unique string key
+     */
+    fun generate(): String
+
+    companion object {
+        /**
+         * Default key generator using UUID.
+         *
+         * Generates 8-character keys from random UUIDs for compact representation
+         * while maintaining uniqueness.
+         */
+        @OptIn(ExperimentalUuidApi::class)
+        val Default: KeyGenerator = KeyGenerator { Uuid.random().toString().take(8) }
+    }
+}

--- a/quo-vadis-core/src/commonTest/kotlin/com/jermey/quo/vadis/core/navigation/FakeNavigator.kt
+++ b/quo-vadis-core/src/commonTest/kotlin/com/jermey/quo/vadis/core/navigation/FakeNavigator.kt
@@ -1,5 +1,6 @@
 package com.jermey.quo.vadis.core.navigation
 
+import com.jermey.quo.vadis.core.InternalQuoVadisApi
 import com.jermey.quo.vadis.core.navigation.config.NavigationConfig
 import com.jermey.quo.vadis.core.dsl.registry.DeepLinkRegistry
 import com.jermey.quo.vadis.core.navigation.pane.PaneRole
@@ -17,10 +18,11 @@ import kotlinx.coroutines.flow.asStateFlow
  * @param config Optional navigation configuration for testing scenarios that need registry access.
  *   Defaults to [NavigationConfig.Empty].
  */
+@OptIn(InternalQuoVadisApi::class)
 @Suppress("TooManyFunctions")
 class FakeNavigator(
     override val config: NavigationConfig = NavigationConfig.Empty
-) : Navigator {
+) : PaneNavigator, TransitionController, ResultCapable {
 
     // =========================================================================
     // TREE-BASED STATE
@@ -205,6 +207,11 @@ class FakeNavigator(
     override fun paneContent(role: PaneRole): NavNode? = null
 
     override fun navigateBackInPane(role: PaneRole): Boolean = navigateBack()
+
+    override fun navigateToPane(destination: NavDestination, role: PaneRole) {
+        // Stub: Just navigate normally for testing purposes
+        navigate(destination)
+    }
 
 
 

--- a/quo-vadis-core/src/commonTest/kotlin/com/jermey/quo/vadis/core/navigation/core/TreeMutatorBackHandlingTest.kt
+++ b/quo-vadis-core/src/commonTest/kotlin/com/jermey/quo/vadis/core/navigation/core/TreeMutatorBackHandlingTest.kt
@@ -8,6 +8,7 @@ import com.jermey.quo.vadis.core.navigation.NavDestination
 import com.jermey.quo.vadis.core.navigation.NavKeyGenerator
 import com.jermey.quo.vadis.core.navigation.NavigationTransition
 import com.jermey.quo.vadis.core.navigation.tree.TreeMutator
+import com.jermey.quo.vadis.core.navigation.tree.result.BackResult
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -76,7 +77,7 @@ class TreeMutatorBackHandlingTest {
 
         val result = TreeMutator.popWithTabBehavior(root)
 
-        assertIs<TreeMutator.BackResult.Handled>(result)
+        assertIs<BackResult.Handled>(result)
         val newState = result.newState
         assertIs<StackNode>(newState)
         assertEquals(1, newState.children.size)
@@ -95,7 +96,7 @@ class TreeMutatorBackHandlingTest {
 
         val result = TreeMutator.popWithTabBehavior(root)
 
-        assertIs<TreeMutator.BackResult.DelegateToSystem>(result)
+        assertIs<BackResult.DelegateToSystem>(result)
     }
 
     @Test
@@ -109,7 +110,7 @@ class TreeMutatorBackHandlingTest {
         val result = TreeMutator.popWithTabBehavior(root)
 
         // Empty root stack delegates to system (same as single-item stack)
-        assertIs<TreeMutator.BackResult.DelegateToSystem>(result)
+        assertIs<BackResult.DelegateToSystem>(result)
     }
 
     @Test
@@ -126,7 +127,7 @@ class TreeMutatorBackHandlingTest {
 
         val result = TreeMutator.popWithTabBehavior(root)
 
-        assertIs<TreeMutator.BackResult.Handled>(result)
+        assertIs<BackResult.Handled>(result)
         val newState = result.newState as StackNode
         assertEquals(2, newState.children.size)
         assertEquals(ProfileDestination, (newState.activeChild as ScreenNode).destination)
@@ -156,7 +157,7 @@ class TreeMutatorBackHandlingTest {
         val result = TreeMutator.popWithTabBehavior(root)
 
         // TabNode is only child of root, so delegate to system (no tab switching)
-        assertIs<TreeMutator.BackResult.DelegateToSystem>(result)
+        assertIs<BackResult.DelegateToSystem>(result)
     }
 
     @Test
@@ -178,7 +179,7 @@ class TreeMutatorBackHandlingTest {
 
         val result = TreeMutator.popWithTabBehavior(root)
 
-        assertIs<TreeMutator.BackResult.DelegateToSystem>(result)
+        assertIs<BackResult.DelegateToSystem>(result)
     }
 
     @Test
@@ -205,7 +206,7 @@ class TreeMutatorBackHandlingTest {
 
         val result = TreeMutator.popWithTabBehavior(root)
 
-        assertIs<TreeMutator.BackResult.Handled>(result)
+        assertIs<BackResult.Handled>(result)
         val newState = result.newState as StackNode
         val newTabNode = newState.children.first() as TabNode
         assertEquals(1, newTabNode.stacks[0].children.size)
@@ -232,7 +233,7 @@ class TreeMutatorBackHandlingTest {
 
         // Back should delegate to system (TabNode is root's only child, cannot pop)
         val result = TreeMutator.popWithTabBehavior(root)
-        assertIs<TreeMutator.BackResult.DelegateToSystem>(result)
+        assertIs<BackResult.DelegateToSystem>(result)
     }
 
     // =========================================================================
@@ -262,7 +263,7 @@ class TreeMutatorBackHandlingTest {
         val result = TreeMutator.popWithTabBehavior(root)
 
         // Should pop from root stack (remove Profile screen)
-        assertIs<TreeMutator.BackResult.Handled>(result)
+        assertIs<BackResult.Handled>(result)
         val newState = result.newState as StackNode
         assertEquals(1, newState.children.size)
         assertIs<TabNode>(newState.children.first())
@@ -383,24 +384,24 @@ class TreeMutatorBackHandlingTest {
     @Test
     fun `BackResult Handled contains new state`() {
         val newState = StackNode("root", null, listOf(ScreenNode("s1", "root", HomeDestination)))
-        val result = TreeMutator.BackResult.Handled(newState)
+        val result = BackResult.Handled(newState)
 
-        assertIs<TreeMutator.BackResult.Handled>(result)
+        assertIs<BackResult.Handled>(result)
         assertEquals(newState, result.newState)
     }
 
     @Test
     fun `BackResult DelegateToSystem is singleton`() {
-        val result1 = TreeMutator.BackResult.DelegateToSystem
-        val result2 = TreeMutator.BackResult.DelegateToSystem
+        val result1 = BackResult.DelegateToSystem
+        val result2 = BackResult.DelegateToSystem
 
         assertTrue(result1 === result2)
     }
 
     @Test
     fun `BackResult CannotHandle is singleton`() {
-        val result1 = TreeMutator.BackResult.CannotHandle
-        val result2 = TreeMutator.BackResult.CannotHandle
+        val result1 = BackResult.CannotHandle
+        val result2 = BackResult.CannotHandle
 
         assertTrue(result1 === result2)
     }
@@ -441,21 +442,21 @@ class TreeMutatorBackHandlingTest {
 
         // Back 1: Pop D from root
         val result1 = TreeMutator.popWithTabBehavior(root)
-        assertIs<TreeMutator.BackResult.Handled>(result1)
+        assertIs<BackResult.Handled>(result1)
         val state1 = result1.newState as StackNode
         assertEquals(1, state1.children.size)
         assertIs<TabNode>(state1.children.first())
 
         // Back 2: Pop B from tab0
         val result2 = TreeMutator.popWithTabBehavior(state1)
-        assertIs<TreeMutator.BackResult.Handled>(result2)
+        assertIs<BackResult.Handled>(result2)
         val state2 = result2.newState as StackNode
         val tabs2 = state2.children.first() as TabNode
         assertEquals(1, tabs2.stacks[0].children.size)
 
         // Back 3: Tab0 at root, delegate to system
         val result3 = TreeMutator.popWithTabBehavior(state2)
-        assertIs<TreeMutator.BackResult.DelegateToSystem>(result3)
+        assertIs<BackResult.DelegateToSystem>(result3)
     }
 
     @Test
@@ -487,7 +488,7 @@ class TreeMutatorBackHandlingTest {
 
         // Back 1: TabNode is only child of root, delegate to system (no tab switching)
         val result1 = TreeMutator.popWithTabBehavior(root)
-        assertIs<TreeMutator.BackResult.DelegateToSystem>(result1)
+        assertIs<BackResult.DelegateToSystem>(result1)
     }
 
     @Test
@@ -506,7 +507,7 @@ class TreeMutatorBackHandlingTest {
         var backCount = 0
         while (TreeMutator.canHandleBackNavigation(current)) {
             val result = TreeMutator.popWithTabBehavior(current)
-            if (result is TreeMutator.BackResult.Handled) {
+            if (result is BackResult.Handled) {
                 current = result.newState
                 backCount++
             } else {
@@ -548,7 +549,7 @@ class TreeMutatorBackHandlingTest {
         val result = TreeMutator.popWithTabBehavior(root)
 
         // Then: Should pop childStack from root, revealing rootScreen
-        assertIs<TreeMutator.BackResult.Handled>(result)
+        assertIs<BackResult.Handled>(result)
         val newState = result.newState as StackNode
         assertEquals(1, newState.children.size)
         assertEquals("r1", newState.activeChild?.key)
@@ -573,7 +574,7 @@ class TreeMutatorBackHandlingTest {
         val result = TreeMutator.popWithTabBehavior(root)
 
         // Then: Should delegate to system since root has only 1 child
-        assertIs<TreeMutator.BackResult.DelegateToSystem>(result)
+        assertIs<BackResult.DelegateToSystem>(result)
     }
 
     @Test
@@ -602,7 +603,7 @@ class TreeMutatorBackHandlingTest {
         val result = TreeMutator.popWithTabBehavior(root)
 
         // Then: Should pop TabNode from root, revealing rootScreen
-        assertIs<TreeMutator.BackResult.Handled>(result)
+        assertIs<BackResult.Handled>(result)
         val newState = result.newState as StackNode
         assertEquals(1, newState.children.size)
         assertEquals("r1", newState.activeChild?.key)
@@ -633,7 +634,7 @@ class TreeMutatorBackHandlingTest {
         val result = TreeMutator.popWithTabBehavior(root)
 
         // Then: Should delegate to system
-        assertIs<TreeMutator.BackResult.DelegateToSystem>(result)
+        assertIs<BackResult.DelegateToSystem>(result)
     }
 
     @Test
@@ -667,7 +668,7 @@ class TreeMutatorBackHandlingTest {
         val result = TreeMutator.popWithTabBehavior(root)
 
         // Then: Should cascade through TabNode and MiddleStack, popping MiddleStack from root
-        assertIs<TreeMutator.BackResult.Handled>(result)
+        assertIs<BackResult.Handled>(result)
         val newState = result.newState as StackNode
         assertEquals(1, newState.children.size)
         assertEquals("r1", newState.activeChild?.key)
@@ -699,7 +700,7 @@ class TreeMutatorBackHandlingTest {
         val result = TreeMutator.popWithTabBehavior(root)
 
         // Then: Should pop child2Stack (parent has multiple children, no cascade needed)
-        assertIs<TreeMutator.BackResult.Handled>(result)
+        assertIs<BackResult.Handled>(result)
         val newState = result.newState as StackNode
         assertEquals(2, newState.children.size)
         assertEquals("child1", newState.activeChild?.key)

--- a/quo-vadis-core/src/commonTest/kotlin/com/jermey/quo/vadis/core/navigation/core/TreeMutatorPaneTest.kt
+++ b/quo-vadis-core/src/commonTest/kotlin/com/jermey/quo/vadis/core/navigation/core/TreeMutatorPaneTest.kt
@@ -13,6 +13,7 @@ import com.jermey.quo.vadis.core.navigation.pane.PaneBackBehavior
 import com.jermey.quo.vadis.core.navigation.pane.PaneConfiguration
 import com.jermey.quo.vadis.core.navigation.pane.PaneRole
 import com.jermey.quo.vadis.core.navigation.tree.TreeMutator
+import com.jermey.quo.vadis.core.navigation.tree.result.PopResult
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -493,8 +494,8 @@ class TreeMutatorPaneTest {
 
         val result = TreeMutator.popWithPaneBehavior(panes)
 
-        assertTrue(result is TreeMutator.PopResult.Popped)
-        val newPanes = (result as TreeMutator.PopResult.Popped).newState as PaneNode
+        assertTrue(result is PopResult.Popped)
+        val newPanes = (result as PopResult.Popped).newState as PaneNode
         val primaryStack = newPanes.paneContent(PaneRole.Primary) as StackNode
         assertEquals(1, primaryStack.children.size)
     }
@@ -520,8 +521,8 @@ class TreeMutatorPaneTest {
         val result = TreeMutator.popWithPaneBehavior(panes)
 
         // PopLatest still pops, leaving an empty stack
-        assertTrue(result is TreeMutator.PopResult.Popped)
-        val newPanes = (result as TreeMutator.PopResult.Popped).newState as PaneNode
+        assertTrue(result is PopResult.Popped)
+        val newPanes = (result as PopResult.Popped).newState as PaneNode
         val primaryStack = newPanes.paneContent(PaneRole.Primary) as StackNode
         assertTrue(primaryStack.isEmpty)
     }
@@ -553,8 +554,8 @@ class TreeMutatorPaneTest {
 
         val result = TreeMutator.popWithPaneBehavior(panes)
 
-        assertTrue(result is TreeMutator.PopResult.Popped)
-        val newPanes = (result as TreeMutator.PopResult.Popped).newState as PaneNode
+        assertTrue(result is PopResult.Popped)
+        val newPanes = (result as PopResult.Popped).newState as PaneNode
         assertEquals(PaneRole.Primary, newPanes.activePaneRole)
     }
 
@@ -578,7 +579,7 @@ class TreeMutatorPaneTest {
 
         val result = TreeMutator.popWithPaneBehavior(panes)
 
-        assertTrue(result is TreeMutator.PopResult.RequiresScaffoldChange)
+        assertTrue(result is PopResult.RequiresScaffoldChange)
     }
 
     @Test
@@ -594,8 +595,8 @@ class TreeMutatorPaneTest {
 
         val result = TreeMutator.popWithPaneBehavior(stack)
 
-        assertTrue(result is TreeMutator.PopResult.Popped)
-        val newStack = (result as TreeMutator.PopResult.Popped).newState as StackNode
+        assertTrue(result is PopResult.Popped)
+        val newStack = (result as PopResult.Popped).newState as StackNode
         assertEquals(1, newStack.children.size)
     }
 
@@ -612,8 +613,8 @@ class TreeMutatorPaneTest {
         val result = TreeMutator.popWithPaneBehavior(stack)
 
         // Pops to empty stack with PRESERVE_EMPTY behavior
-        assertTrue(result is TreeMutator.PopResult.Popped)
-        val newStack = (result as TreeMutator.PopResult.Popped).newState as StackNode
+        assertTrue(result is PopResult.Popped)
+        val newStack = (result as PopResult.Popped).newState as StackNode
         assertTrue(newStack.isEmpty)
     }
 

--- a/quo-vadis-core/src/commonTest/kotlin/com/jermey/quo/vadis/core/navigation/core/TreeMutatorPopTest.kt
+++ b/quo-vadis-core/src/commonTest/kotlin/com/jermey/quo/vadis/core/navigation/core/TreeMutatorPopTest.kt
@@ -8,6 +8,7 @@ import com.jermey.quo.vadis.core.navigation.NavDestination
 import com.jermey.quo.vadis.core.navigation.NavKeyGenerator
 import com.jermey.quo.vadis.core.navigation.NavigationTransition
 import com.jermey.quo.vadis.core.navigation.tree.TreeMutator
+import com.jermey.quo.vadis.core.navigation.tree.config.PopBehavior
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -97,7 +98,7 @@ class TreeMutatorPopTest {
             )
         )
 
-        val result = TreeMutator.pop(root, TreeMutator.PopBehavior.PRESERVE_EMPTY)
+        val result = TreeMutator.pop(root, PopBehavior.PRESERVE_EMPTY)
 
         // PRESERVE_EMPTY returns a tree with empty stack
         assertNotNull(result)
@@ -128,7 +129,7 @@ class TreeMutatorPopTest {
             children = listOf(innerStack)
         )
 
-        val result = TreeMutator.pop(outerStack, TreeMutator.PopBehavior.PRESERVE_EMPTY)
+        val result = TreeMutator.pop(outerStack, PopBehavior.PRESERVE_EMPTY)
 
         // PRESERVE_EMPTY keeps the structure - inner stack becomes empty
         assertNotNull(result)
@@ -507,7 +508,7 @@ class TreeMutatorPopTest {
             activeStackIndex = 0
         )
 
-        val result = TreeMutator.pop(tabs, TreeMutator.PopBehavior.CASCADE)
+        val result = TreeMutator.pop(tabs, PopBehavior.CASCADE)
 
         // CASCADE in tabs falls back to preserving empty stack
         assertNotNull(result)
@@ -534,7 +535,7 @@ class TreeMutatorPopTest {
         )
 
         // Pop from inner stack - with CASCADE, should try to remove empty inner
-        val result = TreeMutator.pop(outerStack, TreeMutator.PopBehavior.CASCADE)
+        val result = TreeMutator.pop(outerStack, PopBehavior.CASCADE)
 
         assertNotNull(result)
         val resultOuter = result as StackNode

--- a/quo-vadis-core/src/commonTest/kotlin/com/jermey/quo/vadis/core/navigation/core/TreeMutatorScopeTest.kt
+++ b/quo-vadis-core/src/commonTest/kotlin/com/jermey/quo/vadis/core/navigation/core/TreeMutatorScopeTest.kt
@@ -178,7 +178,7 @@ class TreeMutatorScopeTest {
         val generateKey = createKeyGenerator()
 
         // SettingsTab exists in tab 1, currently active is tab 0
-        val result = TreeMutator.push(tree, MainTabs.SettingsTab, testRegistry, generateKey)
+        val result = TreeMutator.push(tree, MainTabs.SettingsTab, testRegistry, generateKey = generateKey)
 
         // Should switch to tab 1 where SettingsTab already exists
         val resultStack = result as StackNode
@@ -198,7 +198,7 @@ class TreeMutatorScopeTest {
         val generateKey = createKeyGenerator()
 
         // HomeTab exists in tab 0 which is already active
-        val result = TreeMutator.push(tree, MainTabs.HomeTab, testRegistry, generateKey)
+        val result = TreeMutator.push(tree, MainTabs.HomeTab, testRegistry, generateKey = generateKey)
 
         // TabNode should still exist with same structure
         val resultStack = result as StackNode
@@ -216,7 +216,7 @@ class TreeMutatorScopeTest {
         val generateKey = createKeyGenerator()
 
         // ProfileTab is in scope but not in any tab's stack
-        val result = TreeMutator.push(tree, MainTabs.ProfileTab, testRegistry, generateKey)
+        val result = TreeMutator.push(tree, MainTabs.ProfileTab, testRegistry, generateKey = generateKey)
 
         // Should push to the active tab's stack (tab 0)
         val resultStack = result as StackNode
@@ -243,7 +243,7 @@ class TreeMutatorScopeTest {
         val tree = buildTestTree()
         val generateKey = createKeyGenerator()
 
-        val result = TreeMutator.push(tree, OutOfScopeDestination, testRegistry, generateKey)
+        val result = TreeMutator.push(tree, OutOfScopeDestination, testRegistry, generateKey = generateKey)
 
         // Should push to root stack, not the tab's active stack
         // Root should now have: TabNode + ScreenNode
@@ -265,7 +265,7 @@ class TreeMutatorScopeTest {
         val tree = buildTestTree()
         val generateKey = createKeyGenerator()
 
-        val result = TreeMutator.push(tree, OutOfScopeDestination, testRegistry, generateKey)
+        val result = TreeMutator.push(tree, OutOfScopeDestination, testRegistry, generateKey = generateKey)
 
         // TabNode should be preserved with original state
         val resultStack = result as StackNode
@@ -287,10 +287,10 @@ class TreeMutatorScopeTest {
         val generateKey = createKeyGenerator()
 
         // Push first out-of-scope destination
-        tree = TreeMutator.push(tree, OutOfScopeDestination, testRegistry, generateKey) as StackNode
+        tree = TreeMutator.push(tree, OutOfScopeDestination, testRegistry, generateKey = generateKey) as StackNode
 
         // Push second out-of-scope destination
-        tree = TreeMutator.push(tree, DetailDestination, testRegistry, generateKey) as StackNode
+        tree = TreeMutator.push(tree, DetailDestination, testRegistry, generateKey = generateKey) as StackNode
 
         // Root should now have: TabNode + OutOfScope + Detail
         assertEquals(3, tree.children.size)
@@ -312,7 +312,7 @@ class TreeMutatorScopeTest {
         val generateKey = createKeyGenerator()
 
         // With Empty registry, even out-of-scope destinations go to active stack
-        val result = TreeMutator.push(tree, OutOfScopeDestination, ScopeRegistry.Empty, generateKey)
+        val result = TreeMutator.push(tree, OutOfScopeDestination, ScopeRegistry.Empty, generateKey = generateKey)
 
         // Should push to active tab stack (backward compatible behavior)
         val resultStack = result as StackNode
@@ -405,7 +405,7 @@ class TreeMutatorScopeTest {
         val generateKey = createKeyGenerator()
 
         // Even with scope registry, TabNode without scopeKey doesn't enforce scope
-        val result = TreeMutator.push(tree, OutOfScopeDestination, testRegistry, generateKey)
+        val result = TreeMutator.push(tree, OutOfScopeDestination, testRegistry, generateKey = generateKey)
 
         // Should push to active tab stack (no scope enforcement)
         val resultStack = result as StackNode
@@ -491,7 +491,7 @@ class TreeMutatorScopeTest {
         val tree = buildNestedTestTree()
         val generateKey = createKeyGenerator()
 
-        val result = TreeMutator.push(tree, OutOfScopeDestination, testRegistry, generateKey)
+        val result = TreeMutator.push(tree, OutOfScopeDestination, testRegistry, generateKey = generateKey)
 
         // Out-of-scope should go to root stack
         val resultStack = result as StackNode
@@ -513,7 +513,7 @@ class TreeMutatorScopeTest {
         val tree = buildNestedTestTree()
         val generateKey = createKeyGenerator()
 
-        val result = TreeMutator.push(tree, MainTabs.SettingsTab, testRegistry, generateKey)
+        val result = TreeMutator.push(tree, MainTabs.SettingsTab, testRegistry, generateKey = generateKey)
 
         // In-scope should go to active tab stack
         val resultStack = result as StackNode

--- a/quo-vadis-core/src/commonTest/kotlin/com/jermey/quo/vadis/core/navigation/core/TreeMutatorStackScopeTest.kt
+++ b/quo-vadis-core/src/commonTest/kotlin/com/jermey/quo/vadis/core/navigation/core/TreeMutatorStackScopeTest.kt
@@ -154,7 +154,7 @@ class TreeMutatorStackScopeTest {
         val generateKey = createKeyGenerator()
 
         // When pushing destination in AuthFlow scope
-        val result = TreeMutator.push(root, AuthFlow.Register, testRegistry, generateKey)
+        val result = TreeMutator.push(root, AuthFlow.Register, testRegistry, generateKey = generateKey)
 
         // Then pushed to same stack (authStack)
         val resultRoot = result as StackNode
@@ -195,8 +195,8 @@ class TreeMutatorStackScopeTest {
         val generateKey = createKeyGenerator()
 
         // When pushing multiple AuthFlow destinations
-        tree = TreeMutator.push(tree, AuthFlow.Register, testRegistry, generateKey)
-        tree = TreeMutator.push(tree, AuthFlow.ForgotPassword, testRegistry, generateKey)
+        tree = TreeMutator.push(tree, AuthFlow.Register, testRegistry, generateKey = generateKey)
+        tree = TreeMutator.push(tree, AuthFlow.ForgotPassword, testRegistry, generateKey = generateKey)
 
         // Then all pushed to authStack
         val resultRoot = tree as StackNode
@@ -242,7 +242,7 @@ class TreeMutatorStackScopeTest {
         val generateKey = createKeyGenerator()
 
         // When pushing destination NOT in AuthFlow scope
-        val result = TreeMutator.push(root, MainFlow.Home, testRegistry, generateKey)
+        val result = TreeMutator.push(root, MainFlow.Home, testRegistry, generateKey = generateKey)
 
         // Then new screen created in parent stack (root)
         val resultRoot = result as StackNode
@@ -291,7 +291,7 @@ class TreeMutatorStackScopeTest {
         val generateKey = createKeyGenerator()
 
         // When pushing out-of-scope destination
-        val result = TreeMutator.push(root, MainFlow.Home, testRegistry, generateKey)
+        val result = TreeMutator.push(root, MainFlow.Home, testRegistry, generateKey = generateKey)
 
         // Then AuthStack is completely preserved
         val resultRoot = result as StackNode
@@ -327,8 +327,8 @@ class TreeMutatorStackScopeTest {
         val generateKey = createKeyGenerator()
 
         // When pushing multiple out-of-scope destinations
-        tree = TreeMutator.push(tree, MainFlow.Home, testRegistry, generateKey)
-        tree = TreeMutator.push(tree, MainFlow.Profile, testRegistry, generateKey)
+        tree = TreeMutator.push(tree, MainFlow.Home, testRegistry, generateKey = generateKey)
+        tree = TreeMutator.push(tree, MainFlow.Profile, testRegistry, generateKey = generateKey)
 
         // Then all pushed to root stack
         val resultRoot = tree as StackNode
@@ -378,7 +378,7 @@ class TreeMutatorStackScopeTest {
         val generateKey = createKeyGenerator()
 
         // When pushing destination in MainFlow (outer) but not in AuthFlow (inner)
-        val result = TreeMutator.push(root, MainFlow.Home, testRegistry, generateKey)
+        val result = TreeMutator.push(root, MainFlow.Home, testRegistry, generateKey = generateKey)
 
         // Then: pushes to outerStack (innerStack's parent)
         val resultRoot = result as StackNode
@@ -429,7 +429,7 @@ class TreeMutatorStackScopeTest {
         val generateKey = createKeyGenerator()
 
         // When pushing destination not in AuthFlow
-        val result = TreeMutator.push(root, MainFlow.Home, testRegistry, generateKey)
+        val result = TreeMutator.push(root, MainFlow.Home, testRegistry, generateKey = generateKey)
 
         // Then: Should push to root (escaping both auth stacks)
         // Note: This depends on the exact algorithm - verifying behavior
@@ -470,7 +470,7 @@ class TreeMutatorStackScopeTest {
         val generateKey = createKeyGenerator()
 
         // When pushing any destination (even from different scope)
-        val result = TreeMutator.push(root, AuthFlow.Login, testRegistry, generateKey)
+        val result = TreeMutator.push(root, AuthFlow.Login, testRegistry, generateKey = generateKey)
 
         // Then pushed to same stack (existing behavior)
         val resultRoot = result as StackNode
@@ -517,7 +517,7 @@ class TreeMutatorStackScopeTest {
         val generateKey = createKeyGenerator()
 
         // When pushing out-of-AuthFlow destination
-        val result = TreeMutator.push(root, MainFlow.Home, testRegistry, generateKey)
+        val result = TreeMutator.push(root, MainFlow.Home, testRegistry, generateKey = generateKey)
 
         // Then: escapes scopedStack, goes to unscopedStack (which accepts all)
         val resultRoot = result as StackNode
@@ -564,7 +564,7 @@ class TreeMutatorStackScopeTest {
         val generateKey = createKeyGenerator()
 
         // When pushing out-of-scope with Empty registry
-        val result = TreeMutator.push(root, MainFlow.Home, ScopeRegistry.Empty, generateKey)
+        val result = TreeMutator.push(root, MainFlow.Home, ScopeRegistry.Empty, generateKey = generateKey)
 
         // Then: pushed to authStack anyway (scope not enforced)
         val resultRoot = result as StackNode
@@ -694,7 +694,7 @@ class TreeMutatorStackScopeTest {
         val generateKey = createKeyGenerator()
 
         // When pushing HomeTabs.Feed (in tab scope, not in stack scope)
-        val result = TreeMutator.push(root, HomeTabs.Feed, combinedScopeRegistry, generateKey)
+        val result = TreeMutator.push(root, HomeTabs.Feed, combinedScopeRegistry, generateKey = generateKey)
 
         // Then: escapes AuthFlow stack, goes to tab's stack (tab0)
         val resultRoot = result as StackNode
@@ -751,7 +751,7 @@ class TreeMutatorStackScopeTest {
         val generateKey = createKeyGenerator()
 
         // When pushing MainFlow.Home (not in HomeTabs or AuthFlow)
-        val result = TreeMutator.push(root, MainFlow.Home, combinedScopeRegistry, generateKey)
+        val result = TreeMutator.push(root, MainFlow.Home, combinedScopeRegistry, generateKey = generateKey)
 
         // Then: escapes auth-stack scope to its parent (tab0)
         // This is the innermost scope first - algorithm returns immediate parent when out-of-scope
@@ -801,7 +801,7 @@ class TreeMutatorStackScopeTest {
 
         val generateKey = createKeyGenerator()
 
-        val result = TreeMutator.push(root, AuthFlow.Register, testRegistry, generateKey)
+        val result = TreeMutator.push(root, AuthFlow.Register, testRegistry, generateKey = generateKey)
 
         val resultRoot = result as StackNode
         val resultAuthStack = resultRoot.children[0] as StackNode
@@ -838,7 +838,7 @@ class TreeMutatorStackScopeTest {
 
         val generateKey = createKeyGenerator()
 
-        val result = TreeMutator.push(root, MainFlow.Home, testRegistry, generateKey)
+        val result = TreeMutator.push(root, MainFlow.Home, testRegistry, generateKey = generateKey)
 
         val resultRoot = result as StackNode
         val resultAuthStack = resultRoot.children[0] as StackNode

--- a/quo-vadis-core/src/iosMain/kotlin/com/jermey/quo/vadis/core/compose/PlatformDefaults.ios.kt
+++ b/quo-vadis-core/src/iosMain/kotlin/com/jermey/quo/vadis/core/compose/PlatformDefaults.ios.kt
@@ -1,2 +1,0 @@
-package com.jermey.quo.vadis.core.compose
-

--- a/quo-vadis-core/src/jsMain/kotlin/com/jermey/quo/vadis/core/compose/PlatformDefaults.js.kt
+++ b/quo-vadis-core/src/jsMain/kotlin/com/jermey/quo/vadis/core/compose/PlatformDefaults.js.kt
@@ -1,2 +1,0 @@
-package com.jermey.quo.vadis.core.compose
-

--- a/quo-vadis-core/src/wasmJsMain/kotlin/com/jermey/quo/vadis/core/compose/PlatformDefaults.wasmJs.kt
+++ b/quo-vadis-core/src/wasmJsMain/kotlin/com/jermey/quo/vadis/core/compose/PlatformDefaults.wasmJs.kt
@@ -1,2 +1,0 @@
-package com.jermey.quo.vadis.core.compose
-

--- a/quo-vadis-ksp/src/main/kotlin/com/jermey/quo/vadis/ksp/models/TransitionInfo.kt
+++ b/quo-vadis-ksp/src/main/kotlin/com/jermey/quo/vadis/ksp/models/TransitionInfo.kt
@@ -8,7 +8,8 @@ import com.google.devtools.ksp.symbol.KSFile
  *
  * Transition info connects a destination class to its transition configuration.
  * The KSP processor uses this to generate `TransitionRegistry` entries
- * that map destination classes to their [NavTransition][com.jermey.quo.vadis.core.navigation.compose.animation.NavTransition] instances.
+ * that map destination classes to their
+ * [NavTransition][com.jermey.quo.vadis.core.navigation.compose.animation.NavTransition] instances.
  *
  * ## Generated Code Usage
  *


### PR DESCRIPTION
This pull request refactors the navigation architecture to improve extensibility and internal API separation. The most significant changes include extracting pane-specific navigation methods into a new `PaneNavigator` interface, introducing an internal opt-in annotation for Quo Vadis APIs, and updating result-passing functionality to use a new internal interface. Several usages and imports are updated to reflect these changes.

### Navigation API refactoring

* Extracted all pane-specific navigation methods (`isPaneAvailable`, `paneContent`, `navigateToPane`, `navigateBackInPane`) from the main `Navigator` interface into a new extension interface `PaneNavigator`, and added a safe cast utility `asPaneNavigator`. This improves separation of concerns and makes pane operations opt-in for consumers. (`quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/PaneNavigator.kt`, [quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/PaneNavigator.ktR1-R62](diffhunk://#diff-3a335141f52fd78531a1ec63ca3555ac1a4748986ddbb6cfd619eff29bc096e5R1-R62))
* Updated usages to call `navigator.asPaneNavigator()?.navigateToPane(...)` instead of directly on `Navigator`, and imported the new extension function where needed. (`composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/messages/ConversationListScreen.kt`, [[1]](diffhunk://#diff-de715a553578dc1ad001f6b2ec1cdeacbb298877c5674cf40b3dfc44356d2c0fR39) [[2]](diffhunk://#diff-de715a553578dc1ad001f6b2ec1cdeacbb298877c5674cf40b3dfc44356d2c0fL81-R83)

### Internal API management

* Introduced a new `@InternalQuoVadisApi` annotation to mark APIs as internal and require explicit opt-in. This helps prevent accidental usage of unstable internal APIs. (`quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/InternalQuoVadisApi.kt`, [quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/InternalQuoVadisApi.ktR1-R20](diffhunk://#diff-cb0535fd423ac1013e90fc03148c2b050c6794337e3e6a0dde3ae4b2490586e2R1-R20))
* Added a new internal interface `ResultCapable` for navigators that support result passing, annotated with `@InternalQuoVadisApi`. (`quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/ResultCapable.kt`, [quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/ResultCapable.ktR1-R19](diffhunk://#diff-18c0cd591cf9aab34855df3f11e6f106e610d8c2dbe0d414ad43fc4c3685e436R1-R19))

### Result passing refactor

* Updated `navigateForResult` and `navigateBackWithResult` extension functions to use the new `ResultCapable` interface instead of accessing `resultManager` directly on `Navigator`. These functions now require opt-in to the internal API and throw an error if called on a navigator that does not support result passing. (`quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/NavigatorResultExtensions.kt`, [[1]](diffhunk://#diff-2c9414f0c94a196e0eecc23d3411c86364d10cbc84e521ffc5972a9fb51e8da1R3-R4) [[2]](diffhunk://#diff-2c9414f0c94a196e0eecc23d3411c86364d10cbc84e521ffc5972a9fb51e8da1R39-L57) [[3]](diffhunk://#diff-2c9414f0c94a196e0eecc23d3411c86364d10cbc84e521ffc5972a9fb51e8da1R89-R101)

### Cleanup and minor changes

* Removed pane and transition-related methods and properties from the main `Navigator` interface, leaving only core navigation and configuration methods. (`quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/Navigator.kt`, [[1]](diffhunk://#diff-8f4698eee2a9f80254cf2d723c4cf9c80eb26fbc958264f7f551a90e65d33847L6) [[2]](diffhunk://#diff-8f4698eee2a9f80254cf2d723c4cf9c80eb26fbc958264f7f551a90e65d33847R48-R58) [[3]](diffhunk://#diff-8f4698eee2a9f80254cf2d723c4cf9c80eb26fbc958264f7f551a90e65d33847L65-L72) [[4]](diffhunk://#diff-8f4698eee2a9f80254cf2d723c4cf9c80eb26fbc958264f7f551a90e65d33847L92-L115) [[5]](diffhunk://#diff-8f4698eee2a9f80254cf2d723c4cf9c80eb26fbc958264f7f551a90e65d33847L186-L219) [[6]](diffhunk://#diff-8f4698eee2a9f80254cf2d723c4cf9c80eb26fbc958264f7f551a90e65d33847L260-L340)
* Minor documentation and serialization updates in `PaneNode`, and import/usage cleanups. (`quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/navigation/PaneNode.kt`, [[1]](diffhunk://#diff-700eb8f9dcfc4dc1d67cb7efc7eb16b6887e25428f3e2085b4e9b90a2e2e9e12L11) [[2]](diffhunk://#diff-700eb8f9dcfc4dc1d67cb7efc7eb16b6887e25428f3e2085b4e9b90a2e2e9e12L56-R56) [[3]](diffhunk://#diff-700eb8f9dcfc4dc1d67cb7efc7eb16b6887e25428f3e2085b4e9b90a2e2e9e12L92-L98)
* Updated internal references in navigation host logic to use the new result type import. (`quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/NavigationHost.kt`, [[1]](diffhunk://#diff-2ccb0dd84003873f904ce1d92f321ed53a92eeee216968263e10d2cc8012f36bR56) [[2]](diffhunk://#diff-2ccb0dd84003873f904ce1d92f321ed53a92eeee216968263e10d2cc8012f36bL246-R247) [[3]](diffhunk://#diff-2ccb0dd84003873f904ce1d92f321ed53a92eeee216968263e10d2cc8012f36bL308-R309)