### PR TITLE
feat(demo): Redesign Explore screen with MVI, glassmorphism, and shar…

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -9,8 +11,8 @@
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.NoActionBar">
         <activity
-            android:exported="true"
-            android:name=".MainActivity">
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -71,6 +71,7 @@ kotlin {
         androidMain.dependencies {
             implementation(compose.preview)
             implementation(compose.materialIconsExtended)
+            implementation(libs.ktor.client.okhttp)
         }
         commonMain.dependencies {
             implementation(libs.kotlinx.coroutines.core)
@@ -96,21 +97,36 @@ kotlin {
 
             implementation(projects.feature1)
             implementation(projects.feature2)
+
+            // Haze for glassmorphism
+            implementation(libs.haze)
+            implementation(libs.haze.materials)
+
+            // Coil for image loading
+            implementation(libs.coil.compose)
+            implementation(libs.coil.network.ktor)
+            implementation(libs.ktor.client.core)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.flowmvi.test)
         }
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
+        }
         jsMain.dependencies {
             implementation(compose.html.core)
             implementation(compose.materialIconsExtended)
+            implementation(libs.ktor.client.js)
         }
         wasmJsMain.dependencies {
             implementation(compose.materialIconsExtended)
+            implementation(libs.ktor.client.js)
         }
         val desktopMain by getting {
             dependencies {
                 implementation(compose.desktop.currentOs)
+                implementation(libs.ktor.client.okhttp)
                 // Desktop JVM doesn't support materialIconsExtended in Compose 1.9.0
             }
         }

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -11,6 +11,8 @@
     <ID>LongMethod:DeepLinkDemoScreen.kt:@Composable private fun DeepLinkDemoScreenContent( padding: PaddingValues, onNavigateViaDeepLink: (String) -> Unit )</ID>
     <ID>LongMethod:DetailScreen.kt:@OptIn(ExperimentalSharedTransitionApi::class) @Composable private fun DetailHeaderCard(itemId: String, transitionScope: TransitionScope?)</ID>
     <ID>LongMethod:DetailScreen.kt:@Screen(MasterDetailDestination.Detail::class) @OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class) @Composable fun DetailScreen( destination: MasterDetailDestination.Detail, navigator: Navigator = koinInject() )</ID>
+    <ID>LongMethod:ExploreDetailScreen.kt:@Composable private fun DetailHeroImage( item: ExploreItem, hazeState: HazeState, scrollOffset: Float )</ID>
+    <ID>LongMethod:ExploreDetailScreen.kt:@Screen(MainTabs.ExploreTab.Detail::class) @Composable fun ExploreDetailScreen( destination: MainTabs.ExploreTab.Detail, navigator: Navigator = koinInject(), modifier: Modifier = Modifier )</ID>
     <ID>LongMethod:HomeScreen.kt:@Composable private fun HomeScreenContent( modifier: Modifier, paddingValues: PaddingValues, onNavigateToMasterDetail: () -> Unit, onNavigateToTabs: () -> Unit, onNavigateToProcess: () -> Unit, onNavigateToStateDriven: () -> Unit, onNavigateToAuthFlow: () -> Unit, onNavigateToResultDemo: () -> Unit, onNavigateToMessagesPane: () -> Unit )</ID>
     <ID>LongMethod:HomeScreen.kt:@OptIn(ExperimentalMaterial3Api::class) @Screen(MainTabs.HomeTab::class) @Composable fun HomeScreen( navigator: Navigator = koinInject(), modifier: Modifier = Modifier )</ID>
     <ID>LongMethod:ItemCard.kt:@OptIn(ExperimentalSharedTransitionApi::class) @Composable fun ItemCard( item: Item, onClick: () -> Unit )</ID>
@@ -18,8 +20,10 @@
     <ID>LongMethod:ProcessStep2BScreen.kt:@Composable private fun ProcessStep2BContent( padding: PaddingValues, previousData: String, companyName: String, taxId: String, industry: String, onCompanyNameChange: (String) -> Unit, onTaxIdChange: (String) -> Unit, onIndustryChange: (String) -> Unit, onBack: () -> Unit, onNext: (String) -> Unit )</ID>
     <ID>LongMethod:ProcessStep3Screen.kt:@Composable private fun ProcessStep3Content( padding: PaddingValues, branch: String, dataParts: List&lt;String>, onBack: () -> Unit, onComplete: () -> Unit )</ID>
     <ID>LongMethod:ProfileScreen.kt:@Composable private fun ProfileEditForm( state: ProfileState.Content, onIntent: (ProfileIntent) -> Unit )</ID>
-    <ID>LongMethod:ProfileScreen.kt:@OptIn(ExperimentalMaterial3Api::class) @Screen(MainTabs.ProfileTab::class) @Composable fun ProfileScreen( container: Store&lt;ProfileState, ProfileIntent, ProfileAction> = rememberContainer&lt;ProfileContainer, ProfileState, ProfileIntent, ProfileAction>() )</ID>
+    <ID>LongMethod:ProfileScreen.kt:@OptIn(ExperimentalMaterial3Api::class) @Screen(MainTabs.ProfileTab::class) @Composable fun ProfileScreen( container: Store&lt;ProfileState, ProfileIntent, ProfileAction> = rememberContainer(qualifier&lt;ProfileContainer>()) )</ID>
     <ID>LongMethod:PromoScreen.kt:@Screen(PromoDestination::class) @OptIn(ExperimentalMaterial3Api::class) @Composable fun PromoScreen( destination: PromoDestination, navigator: Navigator = koinInject() )</ID>
+    <ID>LongMethod:QuickPreviewSheet.kt:@Composable private fun PreviewHeroImage( item: ExploreItem, hazeState: HazeState )</ID>
+    <ID>LongMethod:SampleExploreData.kt:SampleExploreData$fun generateItems(): List&lt;ExploreItem></ID>
     <ID>LongMethod:SearchResultsScreen.kt:@Composable private fun SearchResultsContent( destination: SearchDestination.Results, padding: PaddingValues )</ID>
     <ID>LongMethod:TabDetailScreens.kt:@Composable private fun DetailContent( modifier: Modifier = Modifier, icon: ImageVector, title: String, subtitle: String, details: List&lt;DetailRow>, description: String )</ID>
     <ID>LongMethod:TabsDemoWrapper.kt:@OptIn(ExperimentalMaterial3Api::class) @TabsContainer(DemoTabs.Companion::class) @Composable fun DemoTabsWrapper( scope: TabsContainerScope, content: @Composable () -> Unit )</ID>
@@ -27,9 +31,18 @@
     <ID>MagicNumber:DetailScreen.kt:150</ID>
     <ID>MagicNumber:DetailScreen.kt:30</ID>
     <ID>MagicNumber:DetailScreen.kt:4</ID>
+    <ID>MagicNumber:ExploreDetailScreen.kt:0.1f</ID>
+    <ID>MagicNumber:ExploreDetailScreen.kt:0.5f</ID>
+    <ID>MagicNumber:ExploreDetailScreen.kt:10</ID>
+    <ID>MagicNumber:ExploreDetailScreen.kt:10.0</ID>
+    <ID>MagicNumber:ExploreDetailScreen.kt:10f</ID>
+    <ID>MagicNumber:FilterSheet.kt:10</ID>
+    <ID>MagicNumber:FilterSheet.kt:10.0</ID>
     <ID>MagicNumber:MessagesPaneContainer.kt:0.25f</ID>
     <ID>MagicNumber:MessagesPaneContainer.kt:0.4f</ID>
     <ID>MagicNumber:MessagesPaneContainer.kt:0.6f</ID>
+    <ID>MagicNumber:QuickPreviewSheet.kt:10</ID>
+    <ID>MagicNumber:QuickPreviewSheet.kt:10.0</ID>
     <ID>MagicNumber:SearchResultsScreen.kt:5</ID>
     <ID>MagicNumber:TabContentScreens.kt:20</ID>
     <ID>MatchingDeclarationName:DemoBackStack.kt:BackStackEntry</ID>
@@ -40,14 +53,18 @@
     <ID>MaxLineLength:DetailScreen.kt:exit = slideOutVertically(tween(ANIMATION_DURATION)) { it / 4 } + fadeOut(tween(ANIMATION_DURATION))</ID>
     <ID>MaxLineLength:DetailScreen.kt:onNavigateToRelated = { navigator.navigate(MasterDetailDestination.Detail(itemId = relatedId)) }</ID>
     <ID>MaxLineLength:MainTabsUI.kt:*</ID>
-    <ID>MaxLineLength:ProfileScreen.kt:container: Store&lt;ProfileState, ProfileIntent, ProfileAction> = rememberContainer&lt;ProfileContainer, ProfileState, ProfileIntent, ProfileAction>()</ID>
-    <ID>MaxLineLength:StateDrivenDemoScreen.kt:val sharedStore = rememberSharedContainer&lt;StateDrivenContainer, StateDrivenState, StateDrivenIntent, StateDrivenAction>()</ID>
+    <ID>MaxLineLength:StateDrivenDemoScreen.kt:val</ID>
     <ID>MaxLineLength:TabContentScreens.kt:tint = if (isFavorite) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant</ID>
     <ID>ReturnCount:StateDrivenContainer.kt:StateDrivenContainer$private fun clearActiveStack(node: NavNode): NavNode?</ID>
     <ID>ReturnCount:StateDrivenContainer.kt:StateDrivenContainer$private fun swapInActiveStack(node: NavNode, index1: Int, index2: Int): NavNode?</ID>
+    <ID>SwallowedException:ExploreContainer.kt:ExploreContainer$e: Exception</ID>
     <ID>SwallowedException:ProfileContainer.kt:ProfileContainer$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ExploreContainer.kt:ExploreContainer$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ProfileContainer.kt:ProfileContainer$e: Exception</ID>
+    <ID>TooManyFunctions:ExploreContainer.kt:ExploreContainer : NavigationContainer</ID>
     <ID>TooManyFunctions:StateDrivenContainer.kt:StateDrivenContainer : SharedNavigationContainer</ID>
     <ID>TooManyFunctions:TabDetailScreens.kt:com.jermey.navplayground.demo.ui.screens.tabs.TabDetailScreens.kt</ID>
+    <ID>UnusedParameter:FilterSheet.kt:hazeState: HazeState</ID>
+    <ID>UnusedParameter:QuickPreviewSheet.kt:hazeState: HazeState</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/composeApp/src/androidMain/kotlin/com/jermey/navplayground/demo/CoilSetup.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/jermey/navplayground/demo/CoilSetup.android.kt
@@ -1,0 +1,10 @@
+package com.jermey.navplayground.demo
+
+import coil3.PlatformContext
+
+/**
+ * Get platform-specific cache directory for Android.
+ */
+internal actual fun getCacheDirectory(context: PlatformContext): String {
+    return context.cacheDir.absolutePath + "/coil_cache"
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/App.kt
@@ -6,13 +6,15 @@ import androidx.compose.runtime.getValue
 import com.jermey.navplayground.demo.DemoApp
 import com.jermey.navplayground.demo.navigationModule
 import com.jermey.navplayground.demo.profileModule
-import com.jermey.navplayground.demo.stateDrivenDemoModule
-import com.jermey.navplayground.demo.tabsDemoModule
 import com.jermey.navplayground.demo.ui.theme.NavPlaygroundTheme
 import com.jermey.navplayground.demo.ui.theme.rememberThemeManager
 import org.koin.compose.KoinApplication
 import org.koin.dsl.koinConfiguration
-import org.koin.ksp.generated.defaultModule
+import org.koin.ksp.generated.com_jermey_feature1_resultdemo_Feature1Module
+import org.koin.ksp.generated.com_jermey_navplayground_demo_ExploreModule
+import org.koin.ksp.generated.com_jermey_navplayground_demo_ProfileModule
+import org.koin.ksp.generated.com_jermey_navplayground_demo_StateDrivenDemoModule
+import org.koin.ksp.generated.com_jermey_navplayground_demo_TabsDemoModule
 
 @Composable
 fun App() {
@@ -20,11 +22,13 @@ fun App() {
     val themeMode by themeManager.themeMode.collectAsState()
     val koinConfiguration = koinConfiguration {
         modules(
-            defaultModule,
             navigationModule,
             profileModule,
-            stateDrivenDemoModule,
-            tabsDemoModule,
+            com_jermey_navplayground_demo_ProfileModule,
+            com_jermey_navplayground_demo_TabsDemoModule,
+            com_jermey_navplayground_demo_StateDrivenDemoModule,
+            com_jermey_navplayground_demo_ExploreModule,
+            com_jermey_feature1_resultdemo_Feature1Module,
         )
     }
     KoinApplication(configuration = koinConfiguration) {

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/CoilSetup.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/CoilSetup.kt
@@ -1,0 +1,74 @@
+package com.jermey.navplayground.demo
+
+import androidx.compose.runtime.Composable
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.compose.setSingletonImageLoaderFactory
+import coil3.disk.DiskCache
+import coil3.memory.MemoryCache
+import coil3.network.ktor3.KtorNetworkFetcherFactory
+import coil3.request.CachePolicy
+import coil3.request.crossfade
+import okio.Path.Companion.toPath
+
+/**
+ * Configures the singleton Coil ImageLoader with crossfade transitions and caching.
+ *
+ * This should be called once at app startup, before any AsyncImage composables are used.
+ */
+@Suppress("FunctionNaming") // Composable functions can start with uppercase
+@Composable
+fun ConfigureCoilImageLoader() {
+    setSingletonImageLoaderFactory { context ->
+        createImageLoader(context)
+    }
+}
+
+/**
+ * Creates a configured ImageLoader for loading images across all platforms.
+ *
+ * Features:
+ * - Crossfade animation enabled (250ms)
+ * - Memory cache enabled (25% of app memory)
+ * - Disk cache enabled (100MB) on platforms that support it
+ * - Ktor networking for KMP support
+ */
+private fun createImageLoader(context: PlatformContext): ImageLoader {
+    return ImageLoader.Builder(context)
+        .components {
+            add(KtorNetworkFetcherFactory())
+        }
+        .crossfade(true)
+        .crossfade(CROSSFADE_DURATION_MS)
+        .memoryCachePolicy(CachePolicy.ENABLED)
+        .memoryCache {
+            MemoryCache.Builder()
+                .maxSizePercent(context, MEMORY_CACHE_PERCENT)
+                .build()
+        }
+        .apply {
+            // Only enable disk cache on platforms that support it
+            val cacheDir = getCacheDirectory(context)
+            if (cacheDir.isNotEmpty()) {
+                diskCachePolicy(CachePolicy.ENABLED)
+                diskCache {
+                    DiskCache.Builder()
+                        .directory(cacheDir.toPath())
+                        .maxSizeBytes(DISK_CACHE_SIZE_BYTES)
+                        .build()
+                }
+            } else {
+                diskCachePolicy(CachePolicy.DISABLED)
+            }
+        }
+        .build()
+}
+
+/**
+ * Get platform-specific cache directory.
+ */
+internal expect fun getCacheDirectory(context: PlatformContext): String
+
+private const val CROSSFADE_DURATION_MS = 150
+private const val MEMORY_CACHE_PERCENT = 0.25
+private const val DISK_CACHE_SIZE_BYTES = 100L * 1024 * 1024 // 100MB

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/DI.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/DI.kt
@@ -1,19 +1,15 @@
 package com.jermey.navplayground.demo
 
 import com.jermey.navplayground.demo.destinations.MainTabs
-import com.jermey.navplayground.demo.ui.screens.profile.ProfileContainer
 import com.jermey.navplayground.demo.ui.screens.profile.ProfileRepository
-import com.jermey.navplayground.demo.ui.screens.statedriven.StateDrivenContainer
-import com.jermey.navplayground.demo.ui.screens.tabs.DemoTabsContainer
 import com.jermey.quo.vadis.core.navigation.config.NavigationConfig
 import com.jermey.quo.vadis.core.navigation.internal.tree.TreeNavigator
 import com.jermey.quo.vadis.core.navigation.navigator.Navigator
-import com.jermey.quo.vadis.flowmvi.navigationContainer
-import com.jermey.quo.vadis.flowmvi.sharedNavigationContainer
 import com.jermey.quo.vadis.generated.ComposeAppNavigationConfig
 import com.jermey.quo.vadis.generated.Feature1NavigationConfig
 import com.jermey.quo.vadis.generated.Feature2NavigationConfig
-import org.koin.core.component.get
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
 import org.koin.dsl.module
 
 val navigationModule = module {
@@ -46,33 +42,20 @@ val navigationModule = module {
 val profileModule = module {
 
     single { ProfileRepository() }
-
-    navigationContainer<ProfileContainer> { scope ->
-        ProfileContainer(
-            scope = scope,
-            repository = scope.get(),
-            debuggable = true
-        )
-    }
 }
 
-/**
- * Koin module for the State-Driven Navigation Demo shared container.
- */
-val stateDrivenDemoModule = module {
-    sharedNavigationContainer<StateDrivenContainer> { scope ->
-        StateDrivenContainer(scope)
-    }
-}
+@Module
+@ComponentScan("com.jermey.navplayground.demo.ui.screens.statedriven")
+class StateDrivenDemoModule
 
-/**
- * Koin module for the Demo Tabs shared container.
- *
- * Registers [DemoTabsContainer] as a shared navigation container,
- * allowing cross-tab state sharing within the DemoTabs.
- */
-val tabsDemoModule = module {
-    sharedNavigationContainer<DemoTabsContainer> { scope ->
-        DemoTabsContainer(scope)
-    }
-}
+@Module
+@ComponentScan("com.jermey.navplayground.demo.ui.screens.tabs")
+class TabsDemoModule
+
+@Module
+@ComponentScan("com.jermey.navplayground.demo.ui.screens.profile")
+class ProfileModule
+
+@Module
+@ComponentScan("com.jermey.navplayground.demo.ui.screens.explore")
+class ExploreModule

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/DemoApp.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/DemoApp.kt
@@ -37,6 +37,9 @@ import org.koin.compose.koinInject
  */
 @Composable
 fun DemoApp() {
+    // Configure Coil ImageLoader for image loading
+    ConfigureCoilImageLoader()
+
     val navigator = koinInject<Navigator>()
 
     // Config is now implicit - NavigationHost reads from navigator

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/destinations/MainTabs.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/destinations/MainTabs.kt
@@ -4,6 +4,7 @@ import com.jermey.navplayground.demo.destinations.MainTabs.ExploreTab
 import com.jermey.navplayground.demo.destinations.MainTabs.HomeTab
 import com.jermey.navplayground.demo.destinations.MainTabs.ProfileTab
 import com.jermey.navplayground.demo.destinations.MainTabs.SettingsTab
+import com.jermey.quo.vadis.annotations.Argument
 import com.jermey.quo.vadis.annotations.Destination
 import com.jermey.quo.vadis.annotations.Stack
 import com.jermey.quo.vadis.annotations.TabItem
@@ -77,12 +78,44 @@ sealed class MainTabs : NavDestination {
     /**
      * Explore tab - Master-detail patterns and deep navigation.
      *
+     * Uses a dedicated stack for the explore feature with Feed, Detail,
+     * and CategoryView destinations for content discovery.
+     *
      * Icon: "explore" (material icon name)
      */
     @TabItem(label = "Explore", icon = "explore")
-    @Destination(route = "main/explore")
+    @Stack(name = "exploreTabStack", startDestination = ExploreTab.Feed::class)
     @Transition(type = TransitionType.Fade)
-    data object ExploreTab : MainTabs()
+    sealed class ExploreTab : MainTabs() {
+        /**
+         * Main explore feed screen.
+         */
+        @Destination(route = "explore/feed")
+        @Transition(type = TransitionType.Fade)
+        data object Feed : ExploreTab()
+
+        /**
+         * Detail screen for a specific explore item.
+         *
+         * @property itemId The unique identifier of the item to display
+         */
+        @Destination(route = "explore/detail/{itemId}")
+        @Transition(type = TransitionType.SlideHorizontal)
+        data class Detail(
+            @Argument val itemId: String
+        ) : ExploreTab()
+
+        /**
+         * Category view showing items filtered by category.
+         *
+         * @property category The category name to filter by
+         */
+        @Destination(route = "explore/category/{category}")
+        @Transition(type = TransitionType.SlideHorizontal)
+        data class CategoryView(
+            @Argument val category: String
+        ) : ExploreTab()
+    }
 
     /**
      * Profile tab - User profile and settings.

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/tabs/MainTabsUI.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/tabs/MainTabsUI.kt
@@ -1,12 +1,15 @@
 package com.jermey.navplayground.demo.tabs
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Circle
@@ -15,22 +18,37 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.jermey.navplayground.demo.destinations.MainTabs
+import com.jermey.navplayground.demo.ui.components.glassmorphism.LocalHazeState
 import com.jermey.quo.vadis.annotations.TabsContainer
 import com.jermey.quo.vadis.core.compose.scope.TabMetadata
 import com.jermey.quo.vadis.core.compose.scope.TabsContainerScope
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
+import dev.chrisbanes.haze.materials.HazeMaterials
 
 /**
  * Tabs container wrapper for the main tabs with bottom navigation.
  *
  * The @TabsContainer annotation pattern gives full control over the scaffold structure
  * while the library handles tab content rendering and state management.
+ *
+ * Features:
+ * - Edge-to-edge display with content extending under navigation bar
+ * - Glassmorphic bottom navigation bar with blur effect
+ * - Haze state provided via LocalHazeState for child screens
  *
  * @param scope The TabsContainerScope providing access to tab state and navigation
  * @param content The content slot where active tab content is rendered
@@ -41,28 +59,98 @@ fun MainTabsContainer(
     scope: TabsContainerScope,
     content: @Composable () -> Unit
 ) {
-    Column(
-        modifier = Modifier.consumeWindowInsets(
-            WindowInsets()
-                .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
-        )
+    val hazeState = remember { HazeState() }
+    
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .consumeWindowInsets(
+                WindowInsets(0, 0, 0, 0)
+                    .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
+            )
     ) {
-        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
-            // Library renders active tab content
-            content()
+        // Content fills entire screen (edge-to-edge, under navigation bar)
+        // Marked as haze source for bottom bar blur effect
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .hazeSource(state = hazeState)
+        ) {
+            // Provide haze state to child screens via CompositionLocal
+            androidx.compose.runtime.CompositionLocalProvider(
+                LocalHazeState provides hazeState
+            ) {
+                content()
+            }
         }
-        MainBottomNavigationBar(
-            modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+        
+        // Glassmorphic bottom navigation bar - overlaid on top
+        GlassBottomNavigationBar(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter),
             activeTabIndex = scope.activeTabIndex,
             tabMetadata = scope.tabMetadata,
             onTabSelected = { index -> scope.switchTab(index) },
-            isTransitioning = scope.isTransitioning
+            isTransitioning = scope.isTransitioning,
+            hazeState = hazeState
         )
     }
 }
 
 /**
- * Bottom navigation bar for the main tabs.
+ * Glassmorphic bottom navigation bar with blur effect.
+ *
+ * Uses [HazeState] to create a frosted glass effect with content visible through the blur.
+ * Supports edge-to-edge display with proper navigation bar insets.
+ *
+ * @param activeTabIndex The currently selected tab index (0-based)
+ * @param tabMetadata Metadata for all tabs (labels, icons, routes)
+ * @param onTabSelected Callback when a tab is selected
+ * @param isTransitioning Whether tab switch animation is in progress
+ * @param hazeState The HazeState for blur effect
+ */
+@OptIn(ExperimentalHazeMaterialsApi::class)
+@Composable
+private fun GlassBottomNavigationBar(
+    modifier: Modifier = Modifier,
+    activeTabIndex: Int,
+    tabMetadata: List<TabMetadata>,
+    onTabSelected: (Int) -> Unit,
+    isTransitioning: Boolean = false,
+    hazeState: HazeState
+) {
+    val hazeStyle = HazeMaterials.ultraThin()
+    
+    NavigationBar(
+        modifier = modifier
+            .hazeEffect(state = hazeState) {
+                style = hazeStyle
+            }
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.7f))
+            .windowInsetsPadding(WindowInsets.navigationBars),
+        containerColor = Color.Transparent,
+        contentColor = MaterialTheme.colorScheme.onSurface
+    ) {
+        tabMetadata.forEachIndexed { index, meta ->
+            NavigationBarItem(
+                icon = {
+                    Icon(
+                        imageVector = meta.icon ?: getTabIconFallback(meta.route),
+                        contentDescription = meta.contentDescription ?: meta.label
+                    )
+                },
+                label = { Text(meta.label) },
+                selected = activeTabIndex == index,
+                onClick = { onTabSelected(index) },
+                enabled = !isTransitioning // Disable during animations
+            )
+        }
+    }
+}
+
+/**
+ * Standard bottom navigation bar without blur effect.
  *
  * Uses [com.jermey.quo.vadis.core.compose.wrapper.TabMetadata] from [com.jermey.quo.vadis.core.compose.wrapper.TabsContainerScope] to render navigation items
  * with proper selection state and click handling.

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/BottomSheetNavigationItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/BottomSheetNavigationItem.kt
@@ -26,7 +26,7 @@ fun BottomSheetNavigationItem(
 ) {
     Surface(
         onClick = onClick,
-        color = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface,
+        color = androidx.compose.ui.graphics.Color.Transparent,
         modifier = Modifier.fillMaxWidth()
     ) {
         Row(

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/ItemCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/ItemCard.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.jermey.navplayground.demo.ui.screens.masterdetail.Item
-import com.jermey.quo.vadis.core.compose.transition.LocalTransitionScope
+import com.jermey.quo.vadis.core.compose.transition.rememberTransitionScope
 
 
 @OptIn(ExperimentalSharedTransitionApi::class)
@@ -32,7 +32,8 @@ fun ItemCard(
     onClick: () -> Unit
 ) {
     // Get transition scope for shared element transitions
-    val transitionScope = LocalTransitionScope.current
+    // Use rememberTransitionScope() for proper animation during navigation
+    val transitionScope = rememberTransitionScope()
 
     // Base card modifier
     val cardModifier = Modifier.fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/NavigationBottomSheetContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/NavigationBottomSheetContent.kt
@@ -7,9 +7,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.AssistantDirection
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Dashboard
+import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.VerifiedUser
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -36,6 +39,7 @@ fun NavigationBottomSheetContent(
         Text(
             "Navigation Patterns",
             style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(16.dp)
         )
 
@@ -47,6 +51,22 @@ fun NavigationBottomSheetContent(
             description = "Main dashboard",
             selected = currentRoute == "home",
             onClick = { onNavigate(MainTabs.HomeTab) }
+        )
+
+        BottomSheetNavigationItem(
+            icon = Icons.Default.Explore,
+            label = "Explore",
+            description = "Discover new content",
+            selected = currentRoute == "explore",
+            onClick = { onNavigate(MainTabs.ExploreTab.Feed) }
+        )
+
+        BottomSheetNavigationItem(
+            icon = Icons.Default.Person,
+            label = "Profile",
+            description = "User profile",
+            selected = currentRoute == "profile",
+            onClick = { onNavigate(MainTabs.ProfileTab) }
         )
 
         BottomSheetNavigationItem(

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/AnimatedSearchBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/AnimatedSearchBar.kt
@@ -1,0 +1,212 @@
+package com.jermey.navplayground.demo.ui.components.explore
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+
+private const val ANIMATION_DURATION_MS = 200
+
+/**
+ * An animated search bar with smooth transitions.
+ *
+ * Behavior:
+ * - Unfocused: Shows search icon on left
+ * - Focused with no text: Shows search icon, cancel button on right
+ * - Focused with text: Shows close icon on left (clears text), search button on right
+ *
+ * @param query Current search query text
+ * @param onQueryChange Callback when query text changes
+ * @param onFocusChange Callback when focus state changes
+ * @param modifier Modifier for the search bar container
+ * @param placeholder Placeholder text shown when query is empty
+ */
+@Composable
+fun AnimatedSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String = "Search..."
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
+
+    val hasText = query.isNotEmpty()
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        TextField(
+            value = query,
+            onValueChange = onQueryChange,
+            modifier = Modifier
+                .weight(1f)
+                .height(52.dp)
+                .focusRequester(focusRequester)
+                .onFocusChanged { focusState ->
+                    isFocused = focusState.isFocused
+                    onFocusChange(focusState.isFocused)
+                },
+            placeholder = {
+                Text(
+                    text = placeholder,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                )
+            },
+            leadingIcon = {
+                LeadingSearchIcon(
+                    hasText = hasText,
+                    onClear = { onQueryChange("") }
+                )
+            },
+            trailingIcon = {
+                // Show search icon inside field when has text (for visual balance)
+                if (hasText) {
+                    IconButton(onClick = { focusManager.clearFocus() }) {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = "Search",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+            },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(onSearch = { focusManager.clearFocus() }),
+            colors = searchFieldColors(),
+            shape = RoundedCornerShape(28.dp)
+        )
+
+        // Cancel button - only when focused and no text
+        AnimatedVisibility(
+            visible = isFocused && !hasText,
+            enter = fadeIn(tween(ANIMATION_DURATION_MS)) +
+                    slideInHorizontally(tween(ANIMATION_DURATION_MS)) { it / 2 },
+            exit = fadeOut(tween(ANIMATION_DURATION_MS)) +
+                    slideOutHorizontally(tween(ANIMATION_DURATION_MS)) { it / 2 }
+        ) {
+            TextButton(
+                onClick = {
+                    focusManager.clearFocus()
+                    onQueryChange("")
+                },
+                modifier = Modifier.padding(start = 4.dp)
+            ) {
+                Text(
+                    text = "Cancel",
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+
+        // Search button - only when has text
+        AnimatedVisibility(
+            visible = hasText,
+            enter = fadeIn(tween(ANIMATION_DURATION_MS)) +
+                    slideInHorizontally(tween(ANIMATION_DURATION_MS)) { it / 2 },
+            exit = fadeOut(tween(ANIMATION_DURATION_MS)) +
+                    slideOutHorizontally(tween(ANIMATION_DURATION_MS)) { it / 2 }
+        ) {
+            TextButton(
+                onClick = { focusManager.clearFocus() },
+                modifier = Modifier.padding(start = 4.dp)
+            ) {
+                Text(
+                    text = "Search",
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LeadingSearchIcon(
+    hasText: Boolean,
+    onClear: () -> Unit
+) {
+    AnimatedContent(
+        targetState = hasText,
+        transitionSpec = {
+            (fadeIn(tween(ANIMATION_DURATION_MS)) + scaleIn(tween(ANIMATION_DURATION_MS)))
+                .togetherWith(fadeOut(tween(ANIMATION_DURATION_MS)) + scaleOut(tween(ANIMATION_DURATION_MS)))
+        },
+        label = "leadingIcon"
+    ) { showClose ->
+        if (showClose) {
+            IconButton(onClick = onClear, modifier = Modifier.size(40.dp)) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Clear",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        } else {
+            IconButton(onClick = { /* No action when search icon */ }, modifier = Modifier.size(40.dp)) {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = "Search",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun searchFieldColors(): TextFieldColors {
+    return TextFieldDefaults.colors(
+        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.75f),
+        focusedIndicatorColor = Color.Transparent,
+        unfocusedIndicatorColor = Color.Transparent,
+        cursorColor = MaterialTheme.colorScheme.primary
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/CategoryChipsRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/CategoryChipsRow.kt
@@ -1,0 +1,123 @@
+package com.jermey.navplayground.demo.ui.components.explore
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import com.jermey.navplayground.demo.ui.screens.explore.ExploreCategory
+
+private const val SELECTED_SCALE = 1.05f
+private const val UNSELECTED_SCALE = 1.0f
+
+/**
+ * A horizontally scrollable row of category filter chips with selection animations.
+ *
+ * @param categories List of available categories
+ * @param selectedCategory Currently selected category
+ * @param onCategorySelected Callback when a category is tapped
+ * @param modifier Modifier for the row container
+ */
+@Composable
+fun CategoryChipsRow(
+    categories: List<ExploreCategory>,
+    selectedCategory: ExploreCategory,
+    onCategorySelected: (ExploreCategory) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val scrollState = rememberScrollState()
+
+    Row(
+        modifier = modifier
+            .horizontalScroll(scrollState)
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        categories.forEach { category ->
+            CategoryChip(category, category == selectedCategory) { onCategorySelected(category) }
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+    }
+}
+
+/** Individual category chip with animated selection state. */
+@Composable
+private fun CategoryChip(
+    category: ExploreCategory,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    val scale by animateFloatAsState(
+        targetValue = if (isSelected) SELECTED_SCALE else UNSELECTED_SCALE,
+        animationSpec = spring(Spring.DampingRatioMediumBouncy, Spring.StiffnessHigh),
+        label = "chipScale"
+    )
+    val containerColor by animateColorAsState(
+        targetValue = if (isSelected) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerHigh
+        },
+        animationSpec = spring(stiffness = Spring.StiffnessMedium),
+        label = "chipContainerColor"
+    )
+    val contentColor by animateColorAsState(
+        targetValue = if (isSelected) {
+            MaterialTheme.colorScheme.onPrimaryContainer
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        },
+        animationSpec = spring(stiffness = Spring.StiffnessMedium),
+        label = "chipContentColor"
+    )
+
+    FilterChip(
+        selected = isSelected,
+        onClick = onClick,
+        label = { Text(category.displayName, style = MaterialTheme.typography.labelLarge, color = contentColor) },
+        leadingIcon = { Icon(category.icon, null, Modifier.size(18.dp), contentColor) },
+        modifier = Modifier.graphicsLayer { scaleX = scale; scaleY = scale },
+        shape = RoundedCornerShape(20.dp),
+        colors = chipColors(containerColor, contentColor),
+        border = chipBorder(isSelected)
+    )
+}
+
+@Composable
+private fun chipColors(containerColor: Color, contentColor: Color) = FilterChipDefaults.filterChipColors(
+    containerColor = containerColor,
+    selectedContainerColor = containerColor,
+    labelColor = contentColor,
+    selectedLabelColor = contentColor,
+    iconColor = contentColor,
+    selectedLeadingIconColor = contentColor
+)
+
+@Composable
+private fun chipBorder(isSelected: Boolean) = FilterChipDefaults.filterChipBorder(
+    borderColor = if (isSelected) Color.Transparent else MaterialTheme.colorScheme.outlineVariant,
+    selectedBorderColor = Color.Transparent,
+    enabled = true,
+    selected = isSelected
+)

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/ExploreCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/ExploreCard.kt
@@ -1,0 +1,397 @@
+package com.jermey.navplayground.demo.ui.components.explore
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope.OverlayClip
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarOutline
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import com.jermey.quo.vadis.core.compose.transition.rememberTransitionScope
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.compose.LocalPlatformContext
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import com.jermey.navplayground.demo.ui.screens.explore.ExploreItem
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
+import dev.chrisbanes.haze.materials.HazeMaterials
+
+private const val CARD_HEIGHT = 200
+private const val PRESSED_SCALE = 0.96f
+private const val DEFAULT_SCALE = 1.0f
+private const val CORNER_RADIUS = 16
+private const val OVERLAY_HEIGHT_FRACTION = 0.45f
+private const val MAX_RATING = 5
+private const val RATING_DECIMAL_MULTIPLIER = 10
+private const val RATING_DECIMAL_DIVISOR = 10.0
+
+@Suppress("MagicNumber") // Standard color hex value
+private val GOLD_COLOR = Color(0xFFFFD700)
+
+/**
+ * A glassmorphic explore card with Coil image loading and Haze frosted glass overlay.
+ *
+ * Features:
+ * - AsyncImage for background image loading with crossfade
+ * - Haze glassmorphic overlay for text area
+ * - Category badge with icon
+ * - Rating display with stars
+ * - Press animation (scale down on press)
+ * - Long-press callback for quick preview
+ *
+ * @param item The explore item to display
+ * @param onClick Callback when card is tapped
+ * @param onLongClick Callback when card is long-pressed
+ * @param modifier Modifier for the card container
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun ExploreCard(
+    item: ExploreItem,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var isPressed by remember { mutableStateOf(false) }
+    val hazeState = remember { HazeState() }
+    // Use rememberTransitionScope() to get a fresh TransitionScope that always uses
+    // the current LocalAnimatedVisibilityScope - this ensures shared elements animate
+    // correctly even for exit content during navigation transitions
+    val transitionScope = rememberTransitionScope()
+
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) PRESSED_SCALE else DEFAULT_SCALE,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessHigh
+        ),
+        label = "cardScale"
+    )
+
+    Surface(
+        modifier = modifier
+            .height(CARD_HEIGHT.dp)
+            .scale(scale)
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onPress = {
+                        isPressed = true
+                        tryAwaitRelease()
+                        isPressed = false
+                    },
+                    onTap = { onClick() },
+                    onLongPress = { onLongClick() }
+                )
+            },
+        shape = RoundedCornerShape(CORNER_RADIUS.dp),
+        shadowElevation = 4.dp,
+        color = MaterialTheme.colorScheme.surfaceContainerLow
+    ) {
+        // Apply shared bounds to entire card content (image + overlay)
+        val contentModifier = Modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(CORNER_RADIUS.dp))
+        val finalContentModifier = if (transitionScope != null) {
+            with(transitionScope.sharedTransitionScope) {
+                contentModifier.sharedBounds(
+                    sharedContentState = rememberSharedContentState(key = "explore-card-content-${item.id}"),
+                    animatedVisibilityScope = transitionScope.animatedVisibilityScope,
+                    clipInOverlayDuringTransition = OverlayClip(RoundedCornerShape(CORNER_RADIUS.dp))
+                )
+            }
+        } else {
+            contentModifier
+        }
+        
+        Box(modifier = finalContentModifier) {
+            CardBackgroundImage(
+                imageUrl = item.imageUrl,
+                contentDescription = item.title,
+                hazeState = hazeState
+            )
+
+            GlassOverlay(
+                hazeState = hazeState,
+                modifier = Modifier.align(Alignment.BottomCenter)
+            ) {
+                CardContent(item = item)
+            }
+            
+            // Category badge positioned above glass overlay (same as detail screen)
+            CategoryBadge(
+                category = item.category,
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(start = 8.dp, bottom = (CARD_HEIGHT * OVERLAY_HEIGHT_FRACTION + 4).dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun CardBackgroundImage(
+    imageUrl: String,
+    contentDescription: String,
+    hazeState: HazeState
+) {
+    val context = LocalPlatformContext.current
+    var imageState by remember { mutableStateOf<AsyncImagePainter.State>(AsyncImagePainter.State.Empty) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .hazeSource(state = hazeState)
+    ) {
+        AsyncImage(
+            model = ImageRequest.Builder(context)
+                .data(imageUrl)
+                .diskCacheKey(imageUrl)
+                .memoryCacheKey(imageUrl)
+                .diskCachePolicy(CachePolicy.ENABLED)
+                .memoryCachePolicy(CachePolicy.ENABLED)
+                .crossfade(true)
+                .build(),
+            contentDescription = contentDescription,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
+            onState = { imageState = it }
+        )
+
+        when (imageState) {
+            is AsyncImagePainter.State.Loading -> LoadingPlaceholder()
+            is AsyncImagePainter.State.Error -> ErrorPlaceholder()
+            else -> { /* Success or Empty - no overlay needed */ }
+        }
+    }
+}
+
+@Composable
+private fun LoadingPlaceholder() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(24.dp),
+            strokeWidth = 2.dp,
+            color = MaterialTheme.colorScheme.primary
+        )
+    }
+}
+
+@Composable
+private fun ErrorPlaceholder() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    listOf(
+                        MaterialTheme.colorScheme.errorContainer,
+                        MaterialTheme.colorScheme.surfaceContainerHighest
+                    )
+                )
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Failed to load",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onErrorContainer
+        )
+    }
+}
+
+@Composable
+private fun GlassOverlay(
+    hazeState: HazeState,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    GlassOverlayBox(
+        hazeState = hazeState,
+        height = (CARD_HEIGHT * OVERLAY_HEIGHT_FRACTION).dp,
+        cornerRadius = RoundedCornerShape(bottomStart = CORNER_RADIUS.dp, bottomEnd = CORNER_RADIUS.dp),
+        modifier = modifier,
+        content = content
+    )
+}
+
+/**
+ * Reusable glassmorphic overlay box with blur effect.
+ * Used for consistent styling in ExploreCard and ExploreDetailScreen.
+ */
+@OptIn(ExperimentalHazeMaterialsApi::class)
+@Composable
+fun GlassOverlayBox(
+    hazeState: HazeState,
+    height: Dp,
+    modifier: Modifier = Modifier,
+    cornerRadius: RoundedCornerShape = RoundedCornerShape(0.dp),
+    backgroundAlpha: Float = 0.2f,
+    content: @Composable () -> Unit
+) {
+    val thinStyle = HazeMaterials.thin()
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(height)
+            .clip(cornerRadius)
+            .hazeEffect(state = hazeState) {
+                style = thinStyle
+            }
+            .background(
+                Color.Black.copy(alpha = backgroundAlpha)
+            )
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun CardContent(item: ExploreItem) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(12.dp),
+        verticalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = Color.White,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            
+            Text(
+                text = item.subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.White.copy(alpha = 0.8f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        RatingDisplay(rating = item.rating)
+    }
+}
+
+@Composable
+private fun RatingDisplay(rating: Float) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        repeat(MAX_RATING) { index ->
+            val isFilled = index < rating.toInt()
+            val isHalfFilled = !isFilled && index < rating
+
+            Icon(
+                imageVector = if (isFilled || isHalfFilled) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                contentDescription = null,
+                modifier = Modifier.size(14.dp),
+                tint = if (isFilled || isHalfFilled) {
+                    GOLD_COLOR
+                } else {
+                    Color.White.copy(alpha = 0.4f)
+                }
+            )
+        }
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = formatRating(rating),
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White.copy(alpha = 0.9f)
+        )
+    }
+}
+
+/**
+ * Formats a rating float to one decimal place (KMP-compatible).
+ */
+private fun formatRating(rating: Float): String {
+    val rounded = (rating * RATING_DECIMAL_MULTIPLIER).toInt() / RATING_DECIMAL_DIVISOR
+    return if (rounded == rounded.toInt().toDouble()) {
+        "${rounded.toInt()}.0"
+    } else {
+        rounded.toString()
+    }
+}
+
+@Composable
+private fun CategoryBadge(
+    category: com.jermey.navplayground.demo.ui.screens.explore.ExploreCategory,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Icon(
+                imageVector = category.icon,
+                contentDescription = null,
+                modifier = Modifier.size(14.dp),
+                tint = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+            Text(
+                text = category.displayName,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/ExploreEmptyState.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/ExploreEmptyState.kt
@@ -1,0 +1,207 @@
+package com.jermey.navplayground.demo.ui.components.explore
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FilterAlt
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.SearchOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.jermey.navplayground.demo.ui.screens.explore.ExploreCategory
+import kotlinx.coroutines.delay
+
+private const val ICON_SIZE = 80
+private const val ANIMATION_DELAY_MS = 100L
+
+/**
+ * Empty state component displayed when no explore items match the current filters.
+ *
+ * Shows an animated illustration with context-aware messaging based on active filters:
+ * - Search query active: "No results for [query]"
+ * - Category filter active: "No [category] items found"
+ * - Both active: Combined message
+ *
+ * @param searchQuery Current search query text
+ * @param selectedCategory Currently selected category filter
+ * @param onClearFilters Callback to clear all active filters
+ * @param modifier Modifier for the empty state container
+ */
+@Composable
+fun ExploreEmptyState(
+    searchQuery: String,
+    selectedCategory: ExploreCategory,
+    onClearFilters: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var isVisible by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        delay(ANIMATION_DELAY_MS)
+        isVisible = true
+    }
+
+    val scale by animateFloatAsState(
+        targetValue = if (isVisible) 1f else 0.8f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "emptyStateScale"
+    )
+
+    val alpha by animateFloatAsState(
+        targetValue = if (isVisible) 1f else 0f,
+        animationSpec = spring(stiffness = Spring.StiffnessLow),
+        label = "emptyStateAlpha"
+    )
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp)
+            .graphicsLayer {
+                this.scaleX = scale
+                this.scaleY = scale
+                this.alpha = alpha
+            },
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        EmptyStateIcon(
+            searchQuery = searchQuery,
+            selectedCategory = selectedCategory
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        EmptyStateTitle(
+            searchQuery = searchQuery,
+            selectedCategory = selectedCategory
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        EmptyStateSubtitle(
+            searchQuery = searchQuery,
+            selectedCategory = selectedCategory
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        AnimatedVisibility(
+            visible = hasActiveFilters(searchQuery, selectedCategory),
+            enter = fadeIn() + scaleIn(),
+            exit = fadeOut() + scaleOut()
+        ) {
+            Button(onClick = onClearFilters) {
+                Text("Clear Filters")
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyStateIcon(
+    searchQuery: String,
+    selectedCategory: ExploreCategory
+) {
+    val icon: ImageVector = when {
+        searchQuery.isNotEmpty() -> Icons.Default.SearchOff
+        selectedCategory != ExploreCategory.ALL -> selectedCategory.icon
+        else -> Icons.Default.Search
+    }
+
+    val tint = when {
+        searchQuery.isNotEmpty() -> MaterialTheme.colorScheme.error.copy(alpha = 0.6f)
+        selectedCategory != ExploreCategory.ALL -> MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+        else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+    }
+
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        modifier = Modifier.size(ICON_SIZE.dp),
+        tint = tint
+    )
+}
+
+@Composable
+private fun EmptyStateTitle(
+    searchQuery: String,
+    selectedCategory: ExploreCategory
+) {
+    val title = when {
+        searchQuery.isNotEmpty() && selectedCategory != ExploreCategory.ALL ->
+            "No results found"
+        searchQuery.isNotEmpty() ->
+            "No results for \"$searchQuery\""
+        selectedCategory != ExploreCategory.ALL ->
+            "No ${selectedCategory.displayName} items"
+        else ->
+            "No items found"
+    }
+
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleLarge,
+        color = MaterialTheme.colorScheme.onSurface,
+        textAlign = TextAlign.Center
+    )
+}
+
+@Composable
+private fun EmptyStateSubtitle(
+    searchQuery: String,
+    selectedCategory: ExploreCategory
+) {
+    val subtitle = when {
+        searchQuery.isNotEmpty() && selectedCategory != ExploreCategory.ALL ->
+            "Try a different search term or category"
+        searchQuery.isNotEmpty() ->
+            "Try different keywords or check your spelling"
+        selectedCategory != ExploreCategory.ALL ->
+            "Try selecting a different category"
+        else ->
+            "Check back later for new content"
+    }
+
+    Text(
+        text = subtitle,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center
+    )
+}
+
+private fun hasActiveFilters(
+    searchQuery: String,
+    selectedCategory: ExploreCategory
+): Boolean = searchQuery.isNotEmpty() || selectedCategory != ExploreCategory.ALL

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/ExploreGrid.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/ExploreGrid.kt
@@ -1,0 +1,103 @@
+package com.jermey.navplayground.demo.ui.components.explore
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.jermey.navplayground.demo.ui.screens.explore.ExploreItem
+
+private const val GRID_COLUMNS = 2
+private const val GRID_SPACING = 12
+
+/**
+ * A grid layout for explore items.
+ *
+ * Features:
+ * - 2-column LazyVerticalGrid layout
+ * - Loading state indicator
+ * - Empty state when no items match filters
+ *
+ * @param items List of explore items to display
+ * @param onItemClick Callback when an item is tapped
+ * @param onItemLongClick Callback when an item is long-pressed
+ * @param modifier Modifier for the grid container
+ * @param contentPadding Padding for the grid content
+ * @param isLoading Whether data is currently loading
+ * @param emptyContent Content to show when items list is empty
+ */
+@Composable
+fun ExploreGrid(
+    items: List<ExploreItem>,
+    onItemClick: (ExploreItem) -> Unit,
+    onItemLongClick: (ExploreItem) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    gridState: LazyGridState = rememberLazyGridState(),
+    isLoading: Boolean = false,
+    emptyContent: @Composable () -> Unit = {}
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        when {
+            isLoading -> LoadingState()
+            items.isEmpty() -> emptyContent()
+            else -> GridContent(
+                items = items,
+                onItemClick = onItemClick,
+                onItemLongClick = onItemLongClick,
+                contentPadding = contentPadding,
+                gridState = gridState
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun GridContent(
+    items: List<ExploreItem>,
+    onItemClick: (ExploreItem) -> Unit,
+    onItemLongClick: (ExploreItem) -> Unit,
+    contentPadding: PaddingValues,
+    gridState: LazyGridState
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(GRID_COLUMNS),
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = contentPadding,
+        state = gridState,
+        horizontalArrangement = Arrangement.spacedBy(GRID_SPACING.dp),
+        verticalArrangement = Arrangement.spacedBy(GRID_SPACING.dp)
+    ) {
+        itemsIndexed(
+            items = items,
+            key = { _, item -> item.id }
+        ) { _, item ->
+            ExploreCard(
+                item = item,
+                onClick = { onItemClick(item) },
+                onLongClick = { onItemLongClick(item) },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/FilterSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/FilterSheet.kt
@@ -1,0 +1,437 @@
+package com.jermey.navplayground.demo.ui.components.explore
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.jermey.navplayground.demo.ui.components.glassmorphism.GlassBottomSheet
+import com.jermey.navplayground.demo.ui.screens.explore.ExploreCategory
+import com.jermey.navplayground.demo.ui.screens.explore.SortOrder
+import dev.chrisbanes.haze.HazeState
+
+private const val CORNER_RADIUS = 16
+private const val MAX_RATING_FILTER = 5f
+private const val RATING_STEPS = 9
+
+@Suppress("MagicNumber")
+private val GOLD_COLOR = Color(0xFFFFD700)
+
+/**
+ * A filter bottom sheet with glassmorphic design for the Explore screen.
+ *
+ * Features:
+ * - Sort order radio buttons
+ * - Rating filter slider
+ * - Category multi-select chips
+ * - Apply button with result count
+ * - Reset button to clear all filters
+ *
+ * @param currentSortOrder Currently selected sort order
+ * @param currentRatingFilter Current minimum rating filter (0-5)
+ * @param selectedCategory Currently selected category
+ * @param categories Available categories to filter by
+ * @param resultCount Number of items matching current filters
+ * @param onSortOrderChange Callback when sort order changes
+ * @param onRatingFilterChange Callback when rating filter changes
+ * @param onCategoryChange Callback when category selection changes
+ * @param onApply Callback when Apply button is clicked
+ * @param onReset Callback when Reset button is clicked
+ * @param onDismiss Callback when sheet is dismissed
+ * @param hazeState The shared HazeState for glassmorphic effects
+ * @param modifier Modifier for the sheet
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FilterSheet(
+    currentSortOrder: SortOrder,
+    currentRatingFilter: Float,
+    selectedCategory: ExploreCategory,
+    categories: List<ExploreCategory>,
+    resultCount: Int,
+    onSortOrderChange: (SortOrder) -> Unit,
+    onRatingFilterChange: (Float) -> Unit,
+    onCategoryChange: (ExploreCategory) -> Unit,
+    onApply: () -> Unit,
+    onReset: () -> Unit,
+    onDismiss: () -> Unit,
+    hazeState: HazeState,
+    modifier: Modifier = Modifier
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    GlassBottomSheet(
+        onDismissRequest = onDismiss,
+        hazeState = hazeState,
+        sheetState = sheetState,
+        modifier = modifier
+    ) {
+        FilterSheetContent(
+            currentSortOrder = currentSortOrder,
+            currentRatingFilter = currentRatingFilter,
+            selectedCategory = selectedCategory,
+            categories = categories,
+            resultCount = resultCount,
+            onSortOrderChange = onSortOrderChange,
+            onRatingFilterChange = onRatingFilterChange,
+            onCategoryChange = onCategoryChange,
+            onApply = onApply,
+            onReset = onReset
+        )
+    }
+}
+
+@Composable
+private fun FilterSheetContent(
+    currentSortOrder: SortOrder,
+    currentRatingFilter: Float,
+    selectedCategory: ExploreCategory,
+    categories: List<ExploreCategory>,
+    resultCount: Int,
+    onSortOrderChange: (SortOrder) -> Unit,
+    onRatingFilterChange: (Float) -> Unit,
+    onCategoryChange: (ExploreCategory) -> Unit,
+    onApply: () -> Unit,
+    onReset: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        // Header with title and reset button
+        FilterHeader(onReset = onReset)
+
+        Spacer(modifier = Modifier.height(16.dp))
+        HorizontalDivider()
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Sort Order Section
+        SortOrderSection(
+            currentSortOrder = currentSortOrder,
+            onSortOrderChange = onSortOrderChange
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Rating Filter Section
+        RatingFilterSection(
+            currentRating = currentRatingFilter,
+            onRatingChange = onRatingFilterChange
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Category Section
+        CategorySection(
+            selectedCategory = selectedCategory,
+            categories = categories,
+            onCategoryChange = onCategoryChange
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // Apply Button with result count
+        ApplyButton(
+            resultCount = resultCount,
+            onApply = onApply
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun FilterHeader(onReset: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.FilterList,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Text(
+                text = "Filters",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+
+        TextButton(onClick = onReset) {
+            Icon(
+                imageVector = Icons.Default.Refresh,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text("Reset")
+        }
+    }
+}
+
+@Composable
+private fun SortOrderSection(
+    currentSortOrder: SortOrder,
+    onSortOrderChange: (SortOrder) -> Unit
+) {
+    Column {
+        Text(
+            text = "Sort By",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
+
+        Column(modifier = Modifier.selectableGroup()) {
+            SortOrder.entries.forEach { sortOrder ->
+                SortOrderOption(
+                    sortOrder = sortOrder,
+                    isSelected = currentSortOrder == sortOrder,
+                    onSelect = { onSortOrderChange(sortOrder) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SortOrderOption(
+    sortOrder: SortOrder,
+    isSelected: Boolean,
+    onSelect: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = isSelected,
+                onClick = onSelect,
+                role = Role.RadioButton
+            )
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        RadioButton(
+            selected = isSelected,
+            onClick = null // handled by row
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = sortOrder.displayName,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+@Composable
+private fun RatingFilterSection(
+    currentRating: Float,
+    onRatingChange: (Float) -> Unit
+) {
+    Column {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Minimum Rating",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Filled.Star,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = GOLD_COLOR
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = formatRatingValue(currentRating),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Slider(
+            value = currentRating,
+            onValueChange = onRatingChange,
+            valueRange = 0f..MAX_RATING_FILTER,
+            steps = RATING_STEPS,
+            colors = SliderDefaults.colors(
+                thumbColor = MaterialTheme.colorScheme.primary,
+                activeTrackColor = MaterialTheme.colorScheme.primary,
+                inactiveTrackColor = MaterialTheme.colorScheme.surfaceContainerHighest
+            ),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp)
+        )
+
+        // Rating labels
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = "Any",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = "5.0",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun CategorySection(
+    selectedCategory: ExploreCategory,
+    categories: List<ExploreCategory>,
+    onCategoryChange: (ExploreCategory) -> Unit
+) {
+    Column {
+        Text(
+            text = "Category",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
+
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            categories.forEach { category ->
+                CategoryChip(
+                    category = category,
+                    isSelected = selectedCategory == category,
+                    onSelect = { onCategoryChange(category) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryChip(
+    category: ExploreCategory,
+    isSelected: Boolean,
+    onSelect: () -> Unit
+) {
+    FilterChip(
+        selected = isSelected,
+        onClick = onSelect,
+        label = {
+            Text(text = category.displayName)
+        },
+        leadingIcon = {
+            if (isSelected) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    modifier = Modifier.size(FilterChipDefaults.IconSize)
+                )
+            } else {
+                Icon(
+                    imageVector = category.icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(FilterChipDefaults.IconSize)
+                )
+            }
+        }
+    )
+}
+
+@Composable
+private fun ApplyButton(
+    resultCount: Int,
+    onApply: () -> Unit
+) {
+    Button(
+        onClick = onApply,
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Text(
+            text = if (resultCount > 0) {
+                "Show $resultCount results"
+            } else {
+                "No results found"
+            },
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(vertical = 4.dp)
+        )
+    }
+}
+
+/**
+ * Formats rating value for display.
+ */
+private fun formatRatingValue(rating: Float): String {
+    return if (rating == 0f) {
+        "Any"
+    } else {
+        val rounded = (rating * 10).toInt() / 10.0
+        if (rounded == rounded.toInt().toDouble()) {
+            "${rounded.toInt()}.0+"
+        } else {
+            "$rounded+"
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/QuickPreviewSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/explore/QuickPreviewSheet.kt
@@ -1,0 +1,353 @@
+package com.jermey.navplayground.demo.ui.components.explore
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.compose.LocalPlatformContext
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import com.jermey.navplayground.demo.ui.components.glassmorphism.GlassBottomSheet
+import com.jermey.navplayground.demo.ui.screens.explore.ExploreItem
+import com.jermey.quo.vadis.core.compose.transition.rememberTransitionScope
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
+import dev.chrisbanes.haze.materials.HazeMaterials
+
+// Image dimensions now standardized in ExploreItem.imageUrlForId()
+private const val HERO_IMAGE_HEIGHT_DP = 220
+private const val CORNER_RADIUS = 16
+private const val MAX_RATING = 5
+private const val CONTENT_REVEAL_DELAY_MS = 100L
+
+@Suppress("MagicNumber")
+private val GOLD_COLOR = Color(0xFFFFD700)
+
+/**
+ * A modal bottom sheet for quick item preview with glassmorphic design.
+ *
+ * Features:
+ * - High-resolution hero image via AsyncImage
+ * - Animated content reveal
+ * - Glassmorphic overlay using Haze
+ * - "View Full Details" navigation button
+ * - Swipe to dismiss support
+ *
+ * @param item The explore item to preview (null hides the sheet)
+ * @param onDismiss Callback when sheet is dismissed
+ * @param onViewDetails Callback when "View Full Details" is clicked
+ * @param hazeState The shared HazeState for glassmorphic effects
+ * @param modifier Modifier for the sheet
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QuickPreviewSheet(
+    item: ExploreItem?,
+    onDismiss: () -> Unit,
+    onViewDetails: (ExploreItem) -> Unit,
+    hazeState: HazeState,
+    modifier: Modifier = Modifier
+) {
+    if (item != null) {
+        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+        GlassBottomSheet(
+            onDismissRequest = onDismiss,
+            hazeState = hazeState,
+            sheetState = sheetState,
+            modifier = modifier
+        ) {
+            QuickPreviewContent(
+                item = item,
+                hazeState = hazeState,
+                onViewDetails = { onViewDetails(item) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuickPreviewContent(
+    item: ExploreItem,
+    hazeState: HazeState,
+    onViewDetails: () -> Unit
+) {
+    var contentVisible by remember { mutableStateOf(false) }
+
+    LaunchedEffect(item) {
+        contentVisible = false
+        kotlinx.coroutines.delay(CONTENT_REVEAL_DELAY_MS)
+        contentVisible = true
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 24.dp)
+    ) {
+        PreviewHeroImage(
+            item = item,
+            hazeState = hazeState
+        )
+
+        AnimatedVisibility(
+            visible = contentVisible,
+            enter = fadeIn(spring(stiffness = Spring.StiffnessLow)) +
+                    slideInVertically(
+                        initialOffsetY = { it / 4 },
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioMediumBouncy,
+                            stiffness = Spring.StiffnessLow
+                        )
+                    )
+        ) {
+            PreviewDetails(
+                item = item,
+                onViewDetails = onViewDetails
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalSharedTransitionApi::class, ExperimentalHazeMaterialsApi::class)
+@Composable
+private fun PreviewHeroImage(
+    item: ExploreItem,
+    hazeState: HazeState
+) {
+    val context = LocalPlatformContext.current
+    var imageState by remember { mutableStateOf<AsyncImagePainter.State>(AsyncImagePainter.State.Empty) }
+    val localHazeState = remember { HazeState() }
+    val thinStyle = HazeMaterials.thin()
+    // Use rememberTransitionScope() for proper animation during navigation
+    val transitionScope = rememberTransitionScope()
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .height(HERO_IMAGE_HEIGHT_DP.dp)
+            .clip(RoundedCornerShape(CORNER_RADIUS.dp))
+            .hazeSource(state = localHazeState)
+    ) {
+        // Apply shared element for image transition from card
+        val imageModifier = Modifier.matchParentSize()
+        val finalImageModifier = if (transitionScope != null) {
+            with(transitionScope.sharedTransitionScope) {
+                imageModifier.sharedElement(
+                    sharedContentState = rememberSharedContentState(key = "explore-preview-image-${item.id}"),
+                    animatedVisibilityScope = transitionScope.animatedVisibilityScope
+                )
+            }
+        } else {
+            imageModifier
+        }
+
+        AsyncImage(
+            model = ImageRequest.Builder(context)
+                .data(ExploreItem.imageUrlForId(item.id))
+                .crossfade(true)
+                .build(),
+            contentDescription = item.title,
+            modifier = finalImageModifier,
+            contentScale = ContentScale.Crop,
+            onState = { imageState = it }
+        )
+
+        when (imageState) {
+            is AsyncImagePainter.State.Loading -> {
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(32.dp),
+                        strokeWidth = 3.dp
+                    )
+                }
+            }
+            else -> { /* Success, Error, or Empty */ }
+        }
+
+        // Glassmorphic category badge overlay
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(12.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .hazeEffect(state = localHazeState) {
+                    style = thinStyle
+                }
+                .background(Color.Black.copy(alpha = 0.3f))
+                .padding(horizontal = 12.dp, vertical = 6.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Icon(
+                    imageVector = item.category.icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = Color.White
+                )
+                Text(
+                    text = item.category.displayName,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = Color.White
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreviewDetails(
+    item: ExploreItem,
+    onViewDetails: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 16.dp)
+    ) {
+        Text(
+            text = item.title,
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Bold,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = item.subtitle,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        PreviewRating(rating = item.rating)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Description placeholder
+        Text(
+            text = buildPreviewDescription(item),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 4,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(
+            onClick = onViewDetails,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("View Full Details")
+            Spacer(modifier = Modifier.width(8.dp))
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun PreviewRating(rating: Float) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        repeat(MAX_RATING) { index ->
+            Icon(
+                imageVector = Icons.Filled.Star,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = if (index < rating.toInt()) GOLD_COLOR else GOLD_COLOR.copy(alpha = 0.3f)
+            )
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = formatRatingDisplay(rating),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+/**
+ * Builds a preview description based on the item properties.
+ */
+private fun buildPreviewDescription(item: ExploreItem): String {
+    return "Discover more about ${item.title.lowercase()}. " +
+           "This ${item.category.displayName.lowercase()} item has been rated " +
+           "${formatRatingDisplay(item.rating)} out of 5 stars. " +
+           "Tap 'View Full Details' to explore everything this has to offer."
+}
+
+/**
+ * Formats rating to one decimal place.
+ */
+private fun formatRatingDisplay(rating: Float): String {
+    val rounded = (rating * 10).toInt() / 10.0
+    return if (rounded == rounded.toInt().toDouble()) {
+        "${rounded.toInt()}.0"
+    } else {
+        rounded.toString()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/glassmorphism/GlassBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/glassmorphism/GlassBottomSheet.kt
@@ -1,0 +1,98 @@
+package com.jermey.navplayground.demo.ui.components.glassmorphism
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
+import dev.chrisbanes.haze.materials.HazeMaterials
+
+private const val CORNER_RADIUS = 28
+
+/**
+ * A glassmorphic modal bottom sheet with blur effect.
+ *
+ * The sheet has a semi-transparent background with a frosted glass blur effect,
+ * allowing content behind it to be visible but blurred.
+ *
+ * @param onDismissRequest Callback when the sheet is dismissed
+ * @param hazeState The HazeState from the parent content to blur
+ * @param modifier Modifier for the sheet
+ * @param sheetState The state of the bottom sheet
+ * @param dragHandle Custom drag handle composable
+ * @param content The content of the bottom sheet
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
+@Composable
+fun GlassBottomSheet(
+    onDismissRequest: () -> Unit,
+    hazeState: HazeState,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(),
+    dragHandle: @Composable (() -> Unit)? = { GlassBottomSheetDragHandle() },
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val hazeStyle = HazeMaterials.ultraThin()
+    
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = Color.Transparent,
+        scrimColor = Color.Black.copy(alpha = 0.32f),
+        shape = RoundedCornerShape(topStart = CORNER_RADIUS.dp, topEnd = CORNER_RADIUS.dp),
+        dragHandle = null, // We'll add drag handle inside our glass container
+        modifier = modifier
+    ) {
+        // Glass effect container - this is where haze is applied
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(topStart = CORNER_RADIUS.dp, topEnd = CORNER_RADIUS.dp))
+                .hazeEffect(state = hazeState) {
+                    style = hazeStyle
+                }
+                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.65f)),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Drag handle inside glass container
+            if (dragHandle != null) {
+                dragHandle()
+            }
+            // Sheet content
+            content()
+        }
+    }
+}
+
+/**
+ * Default drag handle for glassmorphic bottom sheet.
+ */
+@Composable
+fun GlassBottomSheetDragHandle() {
+    Box(
+        modifier = Modifier
+            .padding(vertical = 12.dp)
+            .width(32.dp)
+            .height(4.dp)
+            .clip(RoundedCornerShape(2.dp))
+            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f))
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/glassmorphism/GlassStyle.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/glassmorphism/GlassStyle.kt
@@ -1,0 +1,15 @@
+package com.jermey.navplayground.demo.ui.components.glassmorphism
+
+/**
+ * Glass style presets for consistent glassmorphism across the app.
+ */
+enum class GlassStyle {
+    /** Thin blur, more transparent. */
+    THIN,
+
+    /** Standard blur, balanced transparency. */
+    REGULAR,
+
+    /** Thick blur, more opaque. */
+    THICK
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/glassmorphism/GlassSurface.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/glassmorphism/GlassSurface.kt
@@ -1,0 +1,85 @@
+package com.jermey.navplayground.demo.ui.components.glassmorphism
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
+import dev.chrisbanes.haze.materials.HazeMaterials
+
+/**
+ * A surface with glassmorphism (frosted glass) effect using Haze.
+ *
+ * Must be used with a [HazeState] that has a source set via `Modifier.hazeSource()`.
+ *
+ * @param hazeState The shared HazeState from the blur source
+ * @param modifier Modifier for the surface
+ * @param style Glass blur intensity preset
+ * @param shape Shape of the glass surface
+ * @param content Content inside the glass surface
+ */
+@OptIn(ExperimentalHazeMaterialsApi::class)
+@Composable
+fun GlassSurface(
+    hazeState: HazeState,
+    modifier: Modifier = Modifier,
+    style: GlassStyle = GlassStyle.REGULAR,
+    shape: Shape = RoundedCornerShape(16.dp),
+    content: @Composable BoxScope.() -> Unit
+) {
+    val hazeStyle = when (style) {
+        GlassStyle.THIN -> HazeMaterials.thin()
+        GlassStyle.REGULAR -> HazeMaterials.regular()
+        GlassStyle.THICK -> HazeMaterials.thick()
+    }
+
+    Box(
+        modifier = modifier
+            .clip(shape)
+            .hazeEffect(state = hazeState) {
+                this.style = hazeStyle
+            },
+        content = content
+    )
+}
+
+/**
+ * A card-like glass surface with elevation shadow.
+ *
+ * @param hazeState The shared HazeState from the blur source
+ * @param modifier Modifier for the card
+ * @param style Glass blur intensity preset
+ * @param cornerRadius Corner radius of the card
+ * @param content Content inside the glass card
+ */
+@Composable
+fun GlassCard(
+    hazeState: HazeState,
+    modifier: Modifier = Modifier,
+    style: GlassStyle = GlassStyle.REGULAR,
+    cornerRadius: Dp = 16.dp,
+    content: @Composable BoxScope.() -> Unit
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(cornerRadius),
+        color = Color.Transparent,
+        shadowElevation = 4.dp
+    ) {
+        GlassSurface(
+            hazeState = hazeState,
+            style = style,
+            shape = RoundedCornerShape(cornerRadius),
+            content = content
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/glassmorphism/HazeScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/components/glassmorphism/HazeScaffold.kt
@@ -1,0 +1,59 @@
+package com.jermey.navplayground.demo.ui.components.glassmorphism
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+
+/**
+ * CompositionLocal providing the current [HazeState] for glassmorphism effects.
+ *
+ * Access via `LocalHazeState.current` within child composables.
+ * Returns null if not inside a [HazeScaffold].
+ */
+val LocalHazeState = compositionLocalOf<HazeState?> { null }
+
+/**
+ * A scaffold that sets up Haze blur source and provides [HazeState] via CompositionLocal.
+ *
+ * Content marked with [Modifier.hazeSource] becomes the blur source.
+ * Child composables can access the state via [LocalHazeState] to apply effects.
+ *
+ * Example usage:
+ * ```kotlin
+ * HazeScaffold { hazeState ->
+ *     // Background content (blur source)
+ *     LazyColumn(modifier = Modifier.fillMaxSize()) { ... }
+ *
+ *     // Glassmorphic overlay (blur effect)
+ *     GlassSurface(hazeState = hazeState, modifier = Modifier.align(Alignment.TopCenter)) {
+ *         SearchBar(...)
+ *     }
+ * }
+ * ```
+ *
+ * @param modifier Modifier for the scaffold
+ * @param content Content that will be the blur source. Receives [HazeState] for manual usage.
+ */
+@Composable
+fun HazeScaffold(
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.(HazeState) -> Unit
+) {
+    val hazeState = remember { HazeState() }
+
+    CompositionLocalProvider(LocalHazeState provides hazeState) {
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .hazeSource(state = hazeState),
+            content = { content(hazeState) }
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/HomeScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -49,7 +48,10 @@ import com.jermey.navplayground.demo.destinations.ProcessDestination
 import com.jermey.navplayground.demo.destinations.StateDrivenDemoDestination
 import com.jermey.navplayground.demo.ui.components.NavigationBottomSheetContent
 import com.jermey.navplayground.demo.ui.components.NavigationPatternCard
+import com.jermey.navplayground.demo.ui.components.glassmorphism.GlassBottomSheet
 import com.jermey.quo.vadis.annotations.Screen
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
 import com.jermey.quo.vadis.core.navigation.navigator.Navigator
 import com.jermey.quo.vadis.core.navigation.transition.NavigationTransitions
 import kotlinx.coroutines.launch
@@ -71,6 +73,7 @@ fun HomeScreen(
     val sheetState = rememberModalBottomSheetState()
     var showBottomSheet by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
+    val hazeState = remember { HazeState() }
 
     Scaffold(
         topBar = {
@@ -85,7 +88,7 @@ fun HomeScreen(
         }
     ) { paddingValues ->
         HomeScreenContent(
-            modifier = modifier,
+            modifier = modifier.hazeSource(state = hazeState),
             paddingValues = paddingValues,
             onNavigateToMasterDetail = {
                 navigator.navigate(
@@ -127,8 +130,9 @@ fun HomeScreen(
     }
 
     if (showBottomSheet) {
-        ModalBottomSheet(
+        GlassBottomSheet(
             onDismissRequest = { showBottomSheet = false },
+            hazeState = hazeState,
             sheetState = sheetState
         ) {
             NavigationBottomSheetContent(
@@ -235,15 +239,7 @@ private fun HomeScreenContent(
             description = "List-detail pane layout for foldables and tablets",
             onClick = onNavigateToMessagesPane
         )
-
-        Spacer(Modifier.weight(1f))
-
-        Text(
-            "Use the bottom navigation to switch between main sections",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
-        )
+        Spacer(modifier = Modifier.height(64.dp))
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/SettingsScreen.kt
@@ -2,7 +2,9 @@ package com.jermey.navplayground.demo.ui.screens
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -18,8 +20,6 @@ import androidx.compose.material.icons.filled.Policy
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -35,7 +35,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.jermey.navplayground.demo.destinations.MainTabs
 import com.jermey.navplayground.demo.ui.components.NavigationBottomSheetContent
+import com.jermey.navplayground.demo.ui.components.glassmorphism.GlassBottomSheet
 import com.jermey.navplayground.demo.ui.components.SettingItem
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
 import com.jermey.navplayground.demo.ui.components.SettingsSection
 import com.jermey.navplayground.demo.ui.components.ThemeSettingItem
 import com.jermey.navplayground.demo.ui.theme.ThemeManager
@@ -59,7 +62,8 @@ fun SettingsScreen(
     val sheetState = rememberModalBottomSheetState()
     var showBottomSheet by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
-    
+    val hazeState = remember { HazeState() }
+
     // Theme manager for theme switching
     val themeManager = rememberThemeManager()
     val currentThemeMode by themeManager.themeMode.collectAsState()
@@ -78,7 +82,7 @@ fun SettingsScreen(
     ) { paddingValues ->
         SettingsScreenContent(
             navigator,
-            modifier,
+            modifier.hazeSource(state = hazeState),
             paddingValues,
             currentThemeMode,
             themeManager
@@ -86,8 +90,9 @@ fun SettingsScreen(
     }
 
     if (showBottomSheet) {
-        ModalBottomSheet(
+        GlassBottomSheet(
             onDismissRequest = { showBottomSheet = false },
+            hazeState = hazeState,
             sheetState = sheetState
         ) {
             NavigationBottomSheetContent(
@@ -117,14 +122,6 @@ private fun SettingsScreenContent(
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        item {
-            Text(
-                "Settings",
-                style = MaterialTheme.typography.headlineMedium,
-                modifier = Modifier.padding(bottom = 16.dp)
-            )
-        }
-
         item {
             SettingsSection("General") {
                 SettingItem(
@@ -171,6 +168,9 @@ private fun SettingsScreenContent(
                 SettingItem("Terms of Service", Icons.Default.Description)
                 SettingItem("Privacy Policy", Icons.Default.Policy)
             }
+        }
+        item {
+            Spacer(modifier = Modifier.height( 64.dp))
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreCategory.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreCategory.kt
@@ -1,0 +1,36 @@
+package com.jermey.navplayground.demo.ui.screens.explore
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Apps
+import androidx.compose.material.icons.filled.Computer
+import androidx.compose.material.icons.filled.Flight
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Park
+import androidx.compose.material.icons.filled.Restaurant
+import androidx.compose.material.icons.filled.SportsBaseball
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * Categories for explore items with display names and icons.
+ */
+enum class ExploreCategory(val displayName: String, val icon: ImageVector) {
+    ALL("All", Icons.Default.Apps),
+    TECHNOLOGY("Technology", Icons.Default.Computer),
+    DESIGN("Design", Icons.Default.Palette),
+    TRAVEL("Travel", Icons.Default.Flight),
+    FOOD("Food", Icons.Default.Restaurant),
+    NATURE("Nature", Icons.Default.Park),
+    MUSIC("Music", Icons.Default.MusicNote),
+    SPORTS("Sports", Icons.Default.SportsBaseball)
+}
+
+/**
+ * Sort order options for explore items.
+ */
+enum class SortOrder(val displayName: String) {
+    RATING_DESC("Rating (High to Low)"),
+    RATING_ASC("Rating (Low to High)"),
+    TITLE_ASC("Title (A-Z)"),
+    TITLE_DESC("Title (Z-A)")
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreContainer.kt
@@ -1,0 +1,247 @@
+package com.jermey.navplayground.demo.ui.screens.explore
+
+import com.jermey.navplayground.demo.destinations.MainTabs
+import com.jermey.quo.vadis.flowmvi.NavigationContainer
+import com.jermey.quo.vadis.flowmvi.NavigationContainerScope
+import org.koin.core.annotation.Qualifier
+import org.koin.core.annotation.Scope
+import org.koin.core.annotation.Scoped
+import pro.respawn.flowmvi.dsl.store
+import pro.respawn.flowmvi.plugins.enableLogging
+import pro.respawn.flowmvi.plugins.recover
+import pro.respawn.flowmvi.plugins.reduce
+
+/**
+ * Type alias for the store context to simplify handler signatures.
+ */
+private typealias Ctx = pro.respawn.flowmvi.api.PipelineContext<ExploreState, ExploreIntent, ExploreAction>
+
+/**
+ * Explore feature container with FlowMVI store.
+ *
+ * Demonstrates:
+ * - Complex filtering and sorting logic
+ * - Search functionality
+ * - Category-based filtering
+ * - Rating filter
+ * - Navigation integration
+ * - Preview modal state
+ *
+ * Uses [NavigationContainer] for proper lifecycle integration with the navigation system.
+ */
+@Scoped
+@Scope(NavigationContainerScope::class)
+@Qualifier(ExploreContainer::class)
+class ExploreContainer(
+    scope: NavigationContainerScope,
+    repository: ExploreRepository,
+    private val debuggable: Boolean = false
+) : NavigationContainer<ExploreState, ExploreIntent, ExploreAction>(scope) {
+
+    // Load data synchronously at construction time for immediate rendering
+    private val initialState: ExploreState = run {
+        val items = repository.getItems()
+        val categories = repository.getCategories()
+        ExploreState.Content(
+            items = items,
+            filteredItems = items.sortedByDescending { it.rating },
+            categories = categories,
+            selectedCategory = ExploreCategory.ALL,
+            searchQuery = "",
+            sortOrder = SortOrder.RATING_DESC,
+            ratingFilter = 0f,
+            isSearchFocused = false,
+            isFilterSheetVisible = false,
+            previewItem = null
+        )
+    }
+
+    override val store = store(initial = initialState) {
+        configure {
+            debuggable = this@ExploreContainer.debuggable
+            name = "ExploreStore"
+            parallelIntents = true // Allow parallel filtering operations
+        }
+
+        // Reduce: handle all intents
+        reduce { intent ->
+            when (intent) {
+                is ExploreIntent.LoadItems -> { /* Data loaded at construction, no-op */ }
+                is ExploreIntent.Search -> handleSearch(intent.query)
+                is ExploreIntent.SelectCategory -> handleSelectCategory(intent.category)
+                is ExploreIntent.SetRatingFilter -> handleSetRatingFilter(intent.minRating)
+                is ExploreIntent.SetSortOrder -> handleSetSortOrder(intent.order)
+                is ExploreIntent.ToggleFilterSheet -> handleToggleFilterSheet()
+                is ExploreIntent.ShowPreview -> handleShowPreview(intent.item)
+                is ExploreIntent.DismissPreview -> handleDismissPreview()
+                is ExploreIntent.NavigateToDetail -> handleNavigateToDetail(intent.item)
+                is ExploreIntent.ClearFilters -> handleClearFilters()
+                is ExploreIntent.SetSearchFocus -> handleSetSearchFocus(intent.focused)
+            }
+        }
+
+        // Recover: handle errors gracefully
+        recover { exception ->
+            action(ExploreAction.ShowError(exception.message ?: "Unknown error"))
+            null // Suppress exception
+        }
+
+        // Enable logging for debugging
+        if (debuggable) {
+            enableLogging()
+        }
+    }
+
+    /**
+     * Handle search query changes.
+     */
+    private suspend fun Ctx.handleSearch(query: String) {
+        withContentState { content ->
+            val updated = content.copy(searchQuery = query)
+            updateState { applyFiltersAndSort(updated) }
+            action(ExploreAction.ScrollToTop)
+        }
+    }
+
+    /**
+     * Handle category selection.
+     */
+    private suspend fun Ctx.handleSelectCategory(category: ExploreCategory) {
+        withContentState { content ->
+            val updated = content.copy(selectedCategory = category)
+            updateState { applyFiltersAndSort(updated) }
+            action(ExploreAction.ScrollToTop)
+        }
+    }
+
+    /**
+     * Handle rating filter changes.
+     */
+    private suspend fun Ctx.handleSetRatingFilter(minRating: Float) {
+        withContentState { content ->
+            val updated = content.copy(ratingFilter = minRating)
+            updateState { applyFiltersAndSort(updated) }
+        }
+    }
+
+    /**
+     * Handle sort order changes.
+     */
+    private suspend fun Ctx.handleSetSortOrder(order: SortOrder) {
+        withContentState { content ->
+            val updated = content.copy(sortOrder = order)
+            updateState { applyFiltersAndSort(updated) }
+        }
+    }
+
+    /**
+     * Toggle filter sheet visibility.
+     */
+    private suspend fun Ctx.handleToggleFilterSheet() {
+        withContentState { content ->
+            updateState { content.copy(isFilterSheetVisible = !content.isFilterSheetVisible) }
+        }
+    }
+
+    /**
+     * Show preview for an item.
+     */
+    private suspend fun Ctx.handleShowPreview(item: ExploreItem) {
+        withContentState { content ->
+            updateState { content.copy(previewItem = item) }
+        }
+    }
+
+    /**
+     * Dismiss preview sheet.
+     */
+    private suspend fun Ctx.handleDismissPreview() {
+        withContentState { content ->
+            updateState { content.copy(previewItem = null) }
+        }
+    }
+
+    /**
+     * Navigate to item detail.
+     */
+    private suspend fun Ctx.handleNavigateToDetail(item: ExploreItem) {
+        try {
+            navigator.navigate(MainTabs.ExploreTab.Detail(itemId = item.id))
+        } catch (e: Exception) {
+            action(ExploreAction.ShowError("Navigation failed"))
+        }
+    }
+
+    /**
+     * Clear all filters.
+     */
+    private suspend fun Ctx.handleClearFilters() {
+        withContentState { content ->
+            val cleared = content.copy(
+                selectedCategory = ExploreCategory.ALL,
+                searchQuery = "",
+                ratingFilter = 0f,
+                sortOrder = SortOrder.RATING_DESC
+            )
+            updateState { applyFiltersAndSort(cleared) }
+            action(ExploreAction.ScrollToTop)
+        }
+    }
+
+    /**
+     * Set search focus state.
+     */
+    private suspend fun Ctx.handleSetSearchFocus(focused: Boolean) {
+        withContentState { content ->
+            updateState { content.copy(isSearchFocused = focused) }
+        }
+    }
+
+    /**
+     * Apply all filters and sorting to the items list.
+     */
+    private fun applyFiltersAndSort(content: ExploreState.Content): ExploreState.Content {
+        var filtered = content.items
+
+        // Apply category filter
+        if (content.selectedCategory != ExploreCategory.ALL) {
+            filtered = filtered.filter { it.category == content.selectedCategory }
+        }
+
+        // Apply search query filter
+        if (content.searchQuery.isNotEmpty()) {
+            val query = content.searchQuery.lowercase()
+            filtered = filtered.filter {
+                it.title.lowercase().contains(query) ||
+                        it.subtitle.lowercase().contains(query) ||
+                        it.category.displayName.lowercase().contains(query)
+            }
+        }
+
+        // Apply rating filter
+        if (content.ratingFilter > 0f) {
+            filtered = filtered.filter { it.rating >= content.ratingFilter }
+        }
+
+        // Apply sorting
+        filtered = when (content.sortOrder) {
+            SortOrder.RATING_DESC -> filtered.sortedByDescending { it.rating }
+            SortOrder.RATING_ASC -> filtered.sortedBy { it.rating }
+            SortOrder.TITLE_ASC -> filtered.sortedBy { it.title }
+            SortOrder.TITLE_DESC -> filtered.sortedByDescending { it.title }
+        }
+
+        return content.copy(filteredItems = filtered)
+    }
+
+    /**
+     * Helper to safely access Content state.
+     */
+    private suspend inline fun Ctx.withContentState(crossinline block: suspend (ExploreState.Content) -> Unit) {
+        withState {
+            if (this is ExploreState.Content) {
+                block(this)
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreContract.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreContract.kt
@@ -1,0 +1,142 @@
+package com.jermey.navplayground.demo.ui.screens.explore
+
+import pro.respawn.flowmvi.api.MVIAction
+import pro.respawn.flowmvi.api.MVIIntent
+import pro.respawn.flowmvi.api.MVIState
+
+/**
+ * MVI State for Explore feature.
+ *
+ * Demonstrates complex state management patterns:
+ * - Loading states (Loading, Content, Error)
+ * - Search and filter state
+ * - Category selection
+ * - Preview modal state
+ */
+sealed interface ExploreState : MVIState {
+    /**
+     * Initial loading state.
+     */
+    data object Loading : ExploreState
+
+    /**
+     * Content state with explore items and filter options.
+     */
+    data class Content(
+        val items: List<ExploreItem>,
+        val filteredItems: List<ExploreItem>,
+        val categories: List<ExploreCategory>,
+        val selectedCategory: ExploreCategory,
+        val searchQuery: String,
+        val sortOrder: SortOrder,
+        val ratingFilter: Float,
+        val isSearchFocused: Boolean,
+        val isFilterSheetVisible: Boolean,
+        val previewItem: ExploreItem?
+    ) : ExploreState {
+        /**
+         * Whether any filters are currently applied.
+         */
+        val isFiltered: Boolean
+            get() = searchQuery.isNotEmpty() ||
+                    selectedCategory != ExploreCategory.ALL ||
+                    ratingFilter > 0f
+    }
+
+    /**
+     * Error state with retry option.
+     */
+    data class Error(val message: String) : ExploreState
+}
+
+/**
+ * MVI Intents for Explore feature.
+ *
+ * Demonstrates various intent types:
+ * - Data loading
+ * - Search and filtering
+ * - Category selection
+ * - Navigation
+ * - UI state changes
+ */
+sealed interface ExploreIntent : MVIIntent {
+    /**
+     * Load explore items (initial or refresh).
+     */
+    data object LoadItems : ExploreIntent
+
+    /**
+     * Search for items by query.
+     */
+    data class Search(val query: String) : ExploreIntent
+
+    /**
+     * Select a category filter.
+     */
+    data class SelectCategory(val category: ExploreCategory) : ExploreIntent
+
+    /**
+     * Set minimum rating filter.
+     */
+    data class SetRatingFilter(val minRating: Float) : ExploreIntent
+
+    /**
+     * Set sort order for items.
+     */
+    data class SetSortOrder(val order: SortOrder) : ExploreIntent
+
+    /**
+     * Toggle filter bottom sheet visibility.
+     */
+    data object ToggleFilterSheet : ExploreIntent
+
+    /**
+     * Show quick preview for an item.
+     */
+    data class ShowPreview(val item: ExploreItem) : ExploreIntent
+
+    /**
+     * Dismiss the quick preview sheet.
+     */
+    data object DismissPreview : ExploreIntent
+
+    /**
+     * Navigate to item detail screen.
+     */
+    data class NavigateToDetail(val item: ExploreItem) : ExploreIntent
+
+    /**
+     * Clear all applied filters.
+     */
+    data object ClearFilters : ExploreIntent
+
+    /**
+     * Update search focus state.
+     */
+    data class SetSearchFocus(val focused: Boolean) : ExploreIntent
+}
+
+/**
+ * MVI Side Effects for Explore feature.
+ *
+ * Demonstrates various action types:
+ * - User feedback (errors)
+ * - Navigation events
+ * - UI commands
+ */
+sealed interface ExploreAction : MVIAction {
+    /**
+     * Show an error message.
+     */
+    data class ShowError(val message: String) : ExploreAction
+
+    /**
+     * Navigate to detail screen.
+     */
+    data class NavigateToDetail(val itemId: String) : ExploreAction
+
+    /**
+     * Scroll the list to top.
+     */
+    data object ScrollToTop : ExploreAction
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreDetailContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreDetailContainer.kt
@@ -1,0 +1,98 @@
+package com.jermey.navplayground.demo.ui.screens.explore
+
+import com.jermey.quo.vadis.flowmvi.NavigationContainer
+import com.jermey.quo.vadis.flowmvi.NavigationContainerScope
+import org.koin.core.annotation.Qualifier
+import org.koin.core.annotation.Scope
+import org.koin.core.annotation.Scoped
+import pro.respawn.flowmvi.api.MVIAction
+import pro.respawn.flowmvi.api.MVIIntent
+import pro.respawn.flowmvi.api.MVIState
+import pro.respawn.flowmvi.api.PipelineContext
+import pro.respawn.flowmvi.dsl.store
+import pro.respawn.flowmvi.plugins.enableLogging
+import pro.respawn.flowmvi.plugins.recover
+import pro.respawn.flowmvi.plugins.reduce
+
+/**
+ * State for the explore detail screen.
+ * Uses Content as initial state with synchronously loaded item to support shared element transitions.
+ */
+sealed interface ExploreDetailState : MVIState {
+    data class Content(val item: ExploreItem) : ExploreDetailState
+    data class Error(val message: String) : ExploreDetailState
+}
+
+/**
+ * Intents for the explore detail screen.
+ */
+sealed interface ExploreDetailIntent : MVIIntent {
+    data object NavigateBack : ExploreDetailIntent
+}
+
+/**
+ * Actions for the explore detail screen.
+ */
+sealed interface ExploreDetailAction : MVIAction {
+    data class ShowError(val message: String) : ExploreDetailAction
+}
+
+private typealias DetailCtx = PipelineContext<ExploreDetailState, ExploreDetailIntent, ExploreDetailAction>
+
+/**
+ * Explore detail feature container with FlowMVI store.
+ *
+ * Demonstrates:
+ * - Synchronous initial state for shared element transitions
+ * - Error handling
+ * - Navigation integration
+ *
+ * Uses [NavigationContainer] for proper lifecycle integration with the navigation system.
+ */
+@Scoped
+@Scope(NavigationContainerScope::class)
+@Qualifier(ExploreDetailContainer::class)
+class ExploreDetailContainer(
+    scope: NavigationContainerScope,
+    repository: ExploreRepository,
+    itemId: String,
+    private val debuggable: Boolean = false
+) : NavigationContainer<ExploreDetailState, ExploreDetailIntent, ExploreDetailAction>(scope) {
+
+    // Initialize with item immediately (synchronous) for shared element transitions
+    private val initialState: ExploreDetailState = repository.getItemById(itemId)
+        ?.let { ExploreDetailState.Content(it) }
+        ?: ExploreDetailState.Error("Item not found")
+
+    override val store = store(initial = initialState) {
+        configure {
+            debuggable = this@ExploreDetailContainer.debuggable
+            name = "ExploreDetailStore"
+            parallelIntents = false
+        }
+
+        reduce { intent ->
+            when (intent) {
+                is ExploreDetailIntent.NavigateBack -> handleNavigateBack()
+            }
+        }
+
+        recover { exception ->
+            action(ExploreDetailAction.ShowError(exception.message ?: "Unknown error"))
+            updateState { ExploreDetailState.Error(exception.message ?: "An error occurred") }
+            null
+        }
+
+        if (debuggable) {
+            enableLogging()
+        }
+    }
+
+    private suspend fun DetailCtx.handleNavigateBack() {
+        try {
+            navigator.navigateBack()
+        } catch (e: Exception) {
+            // Already at root, ignore
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreDetailScreen.kt
@@ -1,0 +1,746 @@
+package com.jermey.navplayground.demo.ui.screens.explore
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope.OverlayClip
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.compose.LocalPlatformContext
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import com.jermey.navplayground.demo.destinations.MainTabs
+import com.jermey.navplayground.demo.ui.components.explore.GlassOverlayBox
+import com.jermey.quo.vadis.annotations.Screen
+import com.jermey.quo.vadis.core.compose.transition.rememberTransitionScope
+import com.jermey.quo.vadis.flowmvi.rememberContainer
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+import org.koin.core.parameter.parametersOf
+import org.koin.core.qualifier.qualifier
+import pro.respawn.flowmvi.api.Store
+import pro.respawn.flowmvi.compose.dsl.subscribe
+
+// Image dimensions now standardized in ExploreItem.imageUrlForId()
+private const val MAX_RATING = 5
+private val EXPANDED_HEIGHT = 280.dp
+private val COLLAPSED_HEIGHT = 56.dp
+private const val OVERLAY_HEIGHT_FRACTION = 0.35f
+
+@Suppress("MagicNumber")
+private val GOLD_COLOR = Color(0xFFFFD700)
+
+/**
+ * Detail screen for an explore item.
+ *
+ * Features:
+ * - Collapsing hero image with parallax effect
+ * - Smooth scroll behavior with system insets support
+ * - Animated content sections
+ * - Back navigation
+ * - Uses NavigationContainer for proper lifecycle integration
+ *
+ * @param destination The Detail destination containing itemId
+ * @param modifier Modifier for the screen
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Screen(MainTabs.ExploreTab.Detail::class)
+@Composable
+fun ExploreDetailScreen(
+    destination: MainTabs.ExploreTab.Detail,
+    modifier: Modifier = Modifier,
+    container: Store<ExploreDetailState, ExploreDetailIntent, ExploreDetailAction> = rememberContainer(
+        qualifier = qualifier<ExploreDetailContainer>(),
+        params = { parametersOf(destination.itemId) }
+    )
+) {
+    val state by container.subscribe { action ->
+        when (action) {
+            is ExploreDetailAction.ShowError -> {
+                // Handle error action if needed (e.g., show snackbar)
+            }
+        }
+    }
+
+    when (val currentState = state) {
+        is ExploreDetailState.Error -> {
+            DetailErrorState(
+                message = currentState.message,
+                onBack = { container.intent(ExploreDetailIntent.NavigateBack) }
+            )
+        }
+        is ExploreDetailState.Content -> {
+            ExploreDetailContent(
+                item = currentState.item,
+                itemId = destination.itemId,
+                onBack = { container.intent(ExploreDetailIntent.NavigateBack) },
+                modifier = modifier
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ExploreDetailContent(
+    item: ExploreItem,
+    itemId: String,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // Use rememberTransitionScope() to get a fresh TransitionScope that always uses
+    // the current LocalAnimatedVisibilityScope
+    val transitionScope = rememberTransitionScope()
+
+    val density = LocalDensity.current
+    val statusBarHeight = with(density) {
+        WindowInsets.statusBars.getTop(this).toDp()
+    }
+
+    // Total header height including status bar
+    val totalExpandedHeight = EXPANDED_HEIGHT + statusBarHeight
+
+    val listState = rememberLazyListState()
+
+    // Calculate collapse progress based on scroll position (0 = expanded, 1 = collapsed)
+    val collapseProgress by remember {
+        derivedStateOf {
+            val scrollOffset = listState.firstVisibleItemScrollOffset.toFloat()
+            val firstIndex = listState.firstVisibleItemIndex
+
+            if (firstIndex > 0) {
+                1f // Fully collapsed if scrolled past first item
+            } else {
+                // Calculate progress based on scroll within the collapse range
+                val collapseRange = with(density) {
+                    (EXPANDED_HEIGHT - COLLAPSED_HEIGHT).toPx()
+                }
+                (scrollOffset / collapseRange).coerceIn(0f, 1f)
+            }
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        // Main scrollable content
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            // Spacer for header area - matches total expanded height
+            item {
+                Spacer(modifier = Modifier.height(totalExpandedHeight))
+            }
+
+            // Content
+            item {
+                DetailContent(item = item, itemId = itemId)
+            }
+        }
+
+        // Pinned collapsing header
+        CollapsingImageHeader(
+            item = item,
+            itemId = itemId,
+            collapseProgress = collapseProgress,
+            statusBarHeight = statusBarHeight,
+            onBack = onBack
+        )
+    }
+}
+
+/**
+ * Collapsing header with hero image that pins at top.
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+private fun CollapsingImageHeader(
+    item: ExploreItem,
+    itemId: String,
+    collapseProgress: Float,
+    statusBarHeight: Dp,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalPlatformContext.current
+    var imageState by remember { mutableStateOf<AsyncImagePainter.State>(AsyncImagePainter.State.Empty) }
+    val transitionScope = rememberTransitionScope()
+    val hazeState = remember { HazeState() }
+    
+    // Calculate current content height (excluding status bar)
+    val currentContentHeight = EXPANDED_HEIGHT - (EXPANDED_HEIGHT - COLLAPSED_HEIGHT) * collapseProgress
+    // Total header height including status bar
+    val totalHeight = currentContentHeight + statusBarHeight
+    
+    val surfaceColor = MaterialTheme.colorScheme.surface
+    val overlayHeight = (EXPANDED_HEIGHT.value * OVERLAY_HEIGHT_FRACTION).dp
+
+    // Single box that spans full height including status bar
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(totalHeight)
+            .clip(RoundedCornerShape(0.dp)) // Clip children to this box
+    ) {
+        // Shared bounds container for image + glass overlay
+        val sharedContentModifier = Modifier
+            .fillMaxWidth()
+            .height(EXPANDED_HEIGHT + statusBarHeight)
+        val finalSharedModifier = if (transitionScope != null) {
+            with(transitionScope.sharedTransitionScope) {
+                sharedContentModifier.sharedBounds(
+                    sharedContentState = rememberSharedContentState(key = "explore-card-content-$itemId"),
+                    animatedVisibilityScope = transitionScope.animatedVisibilityScope,
+                    clipInOverlayDuringTransition = OverlayClip(RoundedCornerShape(0.dp))
+                )
+            }
+        } else {
+            sharedContentModifier
+        }
+        
+        Box(modifier = finalSharedModifier) {
+            // Hero Image - acts as haze source
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(ExploreItem.imageUrlForId(item.id))
+                    .crossfade(true)
+                    .build(),
+                contentDescription = item.title,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .hazeSource(state = hazeState),
+                contentScale = ContentScale.Crop,
+                alignment = Alignment.TopCenter,
+                onState = { imageState = it }
+            )
+
+            // Loading state
+            if (imageState is AsyncImagePainter.State.Loading) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(40.dp))
+                }
+            }
+
+            // Glassmorphic overlay at bottom with title and rating
+            GlassOverlayBox(
+                hazeState = hazeState,
+                height = overlayHeight,
+                backgroundAlpha = 0.3f,
+                modifier = Modifier.align(Alignment.BottomCenter)
+            ) {
+                // Content overlay with title and rating
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column {
+                        Text(
+                            text = item.title,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = Color.White,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        
+                        Text(
+                            text = item.subtitle,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.White.copy(alpha = 0.8f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+
+                    // Rating display
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        repeat(MAX_RATING) { index ->
+                            Icon(
+                                imageVector = Icons.Filled.Star,
+                                contentDescription = null,
+                                modifier = Modifier.size(14.dp),
+                                tint = if (index < item.rating.toInt()) GOLD_COLOR else GOLD_COLOR.copy(alpha = 0.3f)
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = formatRating(item.rating),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = Color.White.copy(alpha = 0.9f)
+                        )
+                    }
+                }
+            }
+            
+            // Category badge - inside shared element for transition
+            Surface(
+                shape = RoundedCornerShape(12.dp),
+                color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f),
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(start = 16.dp, bottom = overlayHeight + 8.dp)
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Icon(
+                        imageVector = item.category.icon,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                    Text(
+                        text = item.category.displayName,
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+            }
+        }
+
+        // Surface color overlay when collapsed - covers entire header including status bar
+        // Outside shared bounds so it fades independently
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(surfaceColor.copy(alpha = collapseProgress * 0.95f))
+        )
+
+        // Top bar content - positioned below status bar
+        // Use renderInSharedTransitionScopeOverlay for fade animation during transition
+        val topBarModifier = Modifier
+            .fillMaxWidth()
+            .padding(top = statusBarHeight)
+            .height(COLLAPSED_HEIGHT)
+            .padding(horizontal = 4.dp)
+        val finalTopBarModifier = if (transitionScope != null) {
+            with(transitionScope.sharedTransitionScope) {
+                topBarModifier.renderInSharedTransitionScopeOverlay(
+                    zIndexInOverlay = 1f
+                )
+            }
+        } else {
+            topBarModifier
+        }
+        
+        // Animated visibility for top bar icons during shared element transition
+        val topBarAlpha = if (transitionScope != null) {
+            with(transitionScope.sharedTransitionScope) {
+                animateFloatAsState(
+                    targetValue = if (transitionScope.animatedVisibilityScope.transition.isRunning) 0f else 1f,
+                    animationSpec = tween(durationMillis = 300),
+                    label = "topBarAlpha"
+                ).value
+            }
+        } else {
+            1f
+        }
+        
+        Row(
+            modifier = finalTopBarModifier.alpha(topBarAlpha),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Back button with background when expanded
+            IconButton(onClick = onBack) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .background(
+                            color = if (collapseProgress < 0.5f) {
+                                MaterialTheme.colorScheme.surface.copy(alpha = 0.7f)
+                            } else {
+                                Color.Transparent
+                            },
+                            shape = CircleShape
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                        tint = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+
+            // Title - fades in as toolbar collapses
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 8.dp)
+                    .alpha(collapseProgress)
+            )
+
+            // Action buttons with background when expanded
+            IconButton(onClick = { /* Bookmark */ }) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .background(
+                            color = if (collapseProgress < 0.5f) {
+                                MaterialTheme.colorScheme.surface.copy(alpha = 0.7f)
+                            } else {
+                                Color.Transparent
+                            },
+                            shape = CircleShape
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Bookmark,
+                        contentDescription = "Bookmark",
+                        tint = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+
+            IconButton(onClick = { /* Share */ }) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .background(
+                            color = if (collapseProgress < 0.5f) {
+                                MaterialTheme.colorScheme.surface.copy(alpha = 0.7f)
+                            } else {
+                                Color.Transparent
+                            },
+                            shape = CircleShape
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Share,
+                        contentDescription = "Share",
+                        tint = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailContent(item: ExploreItem, itemId: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(16.dp)
+    ) {
+        // Description Section
+        DetailSection(title = "About") {
+            Text(
+                text = buildDetailDescription(item),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Specifications Section
+        DetailSection(title = "Details") {
+            DetailSpecRow(label = "Category", value = item.category.displayName)
+            DetailSpecRow(label = "Rating", value = "${formatRating(item.rating)} / 5.0")
+            DetailSpecRow(label = "Status", value = if (item.isFeatured) "Featured" else "Standard")
+            DetailSpecRow(label = "ID", value = item.id)
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Features Section
+        DetailSection(title = "Key Features") {
+            FeatureBullet("High-quality content curated by experts")
+            FeatureBullet("Regular updates with new information")
+            FeatureBullet("Community ratings and reviews")
+            FeatureBullet("Bookmark for offline access")
+            FeatureBullet("Share with friends and colleagues")
+            FeatureBullet("Cross-platform availability")
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Extended Description
+        DetailSection(title = "Overview") {
+            Text(
+                text = buildExtendedDescription(item),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Statistics Section
+        DetailSection(title = "Statistics") {
+            DetailSpecRow(label = "Views", value = "${(item.id.hashCode().toLong() and 0xFFFFL) + 1000}")
+            DetailSpecRow(label = "Bookmarks", value = "${(item.id.hashCode().toLong() and 0xFFL) + 50}")
+            DetailSpecRow(label = "Shares", value = "${(item.id.hashCode().toLong() and 0x7FL) + 25}")
+            DetailSpecRow(label = "Comments", value = "${(item.id.hashCode().toLong() and 0x3FL) + 10}")
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Tags Section
+        DetailSection(title = "Tags") {
+            Text(
+                text = generateTags(item),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Related Items Section
+        DetailSection(title = "Related") {
+            Text(
+                text = "Explore more ${item.category.displayName.lowercase()} items...",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "• Similar items in this category\n• Popular picks this week\n• Editor's recommendations\n• Trending content",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Additional Info
+        DetailSection(title = "Additional Information") {
+            Text(
+                text = "This content is part of our curated collection. We continuously update our " +
+                        "catalog to bring you the best and most relevant information. If you have any " +
+                        "feedback or suggestions, please don't hesitate to reach out through our support channels.\n\n" +
+                        "Last updated: January 2026\n" +
+                        "Content version: 2.0\n" +
+                        "Available languages: English, Spanish, French, German, Japanese",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        // Bottom spacing for scroll overscroll
+        Spacer(modifier = Modifier.height(100.dp))
+    }
+}
+
+@Composable
+private fun FeatureBullet(text: String) {
+    Row(
+        modifier = Modifier.padding(vertical = 4.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            text = "•",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(end = 8.dp)
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+@Composable
+private fun DetailSection(
+    title: String,
+    content: @Composable () -> Unit
+) {
+    Column {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
+        content()
+    }
+}
+
+@Composable
+private fun DetailSpecRow(
+    label: String,
+    value: String
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+@Composable
+private fun DetailErrorState(
+    message: String,
+    onBack: () -> Unit
+) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.error
+            )
+            Surface(
+                onClick = onBack,
+                shape = RoundedCornerShape(8.dp),
+                color = MaterialTheme.colorScheme.primaryContainer
+            ) {
+                Text(
+                    text = "Go Back",
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Builds a detailed description for the item.
+ */
+private fun buildDetailDescription(item: ExploreItem): String {
+    return "Welcome to ${item.title}! ${item.subtitle}. " +
+           "This exceptional ${item.category.displayName.lowercase()} item has garnered " +
+           "a rating of ${formatRating(item.rating)} out of 5 stars from our community. " +
+           if (item.isFeatured) {
+               "As a featured item, it represents the best in its category. "
+           } else {
+               ""
+           } +
+           "Explore all the details and discover what makes this item special."
+}
+
+/**
+ * Builds an extended description for the item.
+ */
+private fun buildExtendedDescription(item: ExploreItem): String {
+    return "Dive deeper into ${item.title} and discover everything it has to offer. " +
+           "Our team of experts has carefully curated this ${item.category.displayName.lowercase()} content " +
+           "to ensure you get the most comprehensive and up-to-date information available.\n\n" +
+           "Whether you're a beginner looking to learn the basics or an expert seeking advanced insights, " +
+           "${item.title} provides valuable knowledge that caters to all skill levels. " +
+           "The content is regularly updated to reflect the latest trends and developments in the field.\n\n" +
+           "Join thousands of other users who have already explored this content and found it valuable. " +
+           "With a rating of ${formatRating(item.rating)} stars, ${item.title} stands out as one of the " +
+           "top picks in our ${item.category.displayName.lowercase()} collection."
+}
+
+/**
+ * Generates tags for the item based on its properties.
+ */
+private fun generateTags(item: ExploreItem): String {
+    val baseTags = listOf(
+        "#${item.category.displayName.lowercase().replace(" ", "")}",
+        "#explore",
+        "#discover",
+        "#learn"
+    )
+    val conditionalTags = if (item.isFeatured) listOf("#featured", "#topPick") else listOf("#trending")
+    val ratingTags = if (item.rating >= 4.5f) listOf("#highlyRated", "#mustSee") else listOf("#recommended")
+    
+    return (baseTags + conditionalTags + ratingTags).joinToString("  ")
+}
+
+/**
+ * Formats rating to one decimal place.
+ */
+private fun formatRating(rating: Float): String {
+    val rounded = (rating * 10).toInt() / 10.0
+    return if (rounded == rounded.toInt().toDouble()) {
+        "${rounded.toInt()}.0"
+    } else {
+        rounded.toString()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreFilterState.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreFilterState.kt
@@ -1,0 +1,115 @@
+package com.jermey.navplayground.demo.ui.screens.explore
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+
+/**
+ * Types of filter changes that can occur when updating the explore grid.
+ */
+enum class FilterChangeType {
+    /** Initial load, no previous state to compare. */
+    INITIAL,
+
+    /** No changes detected between previous and current items. */
+    NONE,
+
+    /** New items were added (filter relaxed or new content loaded). */
+    ITEMS_ADDED,
+
+    /** Items were removed (filter applied more strictly). */
+    ITEMS_REMOVED,
+
+    /** Both additions and removals occurred (different filter applied). */
+    BOTH
+}
+
+/**
+ * Tracks filter state changes to animate grid content appropriately.
+ *
+ * This class helps determine what kind of animation to apply when the
+ * filtered items list changes:
+ * - [FilterChangeType.INITIAL]: First load, fade in all items
+ * - [FilterChangeType.ITEMS_ADDED]: New items appeared, animate them in
+ * - [FilterChangeType.ITEMS_REMOVED]: Items disappeared, animate them out
+ * - [FilterChangeType.BOTH]: Items changed, crossfade transition
+ * - [FilterChangeType.NONE]: No change, skip animation
+ *
+ * Usage:
+ * ```kotlin
+ * val filterState = rememberExploreFilterState()
+ * val changeType = filterState.update(currentItems.map { it.id }.toSet())
+ *
+ * when (changeType) {
+ *     FilterChangeType.ITEMS_ADDED -> // animate new items in
+ *     FilterChangeType.ITEMS_REMOVED -> // animate removed items out
+ *     // ...
+ * }
+ * ```
+ */
+@Stable
+class ExploreFilterState {
+    /**
+     * Set of item IDs from the previous update.
+     */
+    var previousItemIds: Set<String> = emptySet()
+        private set
+
+    /**
+     * Whether this is the first update (no previous state).
+     */
+    private var isFirstUpdate: Boolean = true
+
+    /**
+     * Updates the tracked state and returns the type of change detected.
+     *
+     * @param currentIds Set of current item IDs after filtering
+     * @return The type of change detected between previous and current state
+     */
+    fun update(currentIds: Set<String>): FilterChangeType {
+        if (isFirstUpdate) {
+            isFirstUpdate = false
+            previousItemIds = currentIds
+            return FilterChangeType.INITIAL
+        }
+
+        val added = currentIds - previousItemIds
+        val removed = previousItemIds - currentIds
+
+        val changeType = when {
+            added.isEmpty() && removed.isEmpty() -> FilterChangeType.NONE
+            added.isNotEmpty() && removed.isNotEmpty() -> FilterChangeType.BOTH
+            added.isNotEmpty() -> FilterChangeType.ITEMS_ADDED
+            else -> FilterChangeType.ITEMS_REMOVED
+        }
+
+        previousItemIds = currentIds
+        return changeType
+    }
+
+    /**
+     * Checks if a specific item is new (wasn't in the previous state).
+     *
+     * @param itemId The ID of the item to check
+     * @return true if the item is newly added
+     */
+    fun isNewItem(itemId: String): Boolean = itemId !in previousItemIds
+
+    /**
+     * Resets the state to initial (useful for pull-to-refresh).
+     */
+    fun reset() {
+        previousItemIds = emptySet()
+        isFirstUpdate = true
+    }
+}
+
+/**
+ * Creates and remembers an [ExploreFilterState] instance.
+ *
+ * @return A remembered instance of ExploreFilterState
+ */
+@Composable
+fun rememberExploreFilterState(): ExploreFilterState {
+    return remember { ExploreFilterState() }
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreItem.kt
@@ -1,0 +1,36 @@
+package com.jermey.navplayground.demo.ui.screens.explore
+
+/**
+ * Data model for explore feed items.
+ *
+ * @property id Unique identifier
+ * @property title Display title
+ * @property subtitle Secondary text
+ * @property category Item category
+ * @property imageUrl URL to picsum.photos image
+ * @property rating Rating (0.0 - 5.0)
+ * @property isFeatured Whether item should be featured/highlighted
+ */
+data class ExploreItem(
+    val id: String,
+    val title: String,
+    val subtitle: String,
+    val category: ExploreCategory,
+    val imageUrl: String,
+    val rating: Float,
+    val isFeatured: Boolean = false
+) {
+    companion object {
+        private const val STANDARD_WIDTH = 800
+        private const val STANDARD_HEIGHT = 600
+
+        /**
+         * Generate deterministic picsum URL based on item ID.
+         *
+         * Uses standardized 800×600 resolution for optimal cache hits across
+         * all usages (card, detail, preview).
+         */
+        fun imageUrlForId(id: String): String =
+            "https://picsum.photos/seed/$id/$STANDARD_WIDTH/$STANDARD_HEIGHT"
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/explore/ExploreRepository.kt
@@ -1,0 +1,329 @@
+package com.jermey.navplayground.demo.ui.screens.explore
+
+import org.koin.core.annotation.Factory
+
+/**
+ * Repository for explore items data.
+ * 
+ * This is a simple in-memory repository for demo purposes.
+ * Data is generated once and cached for the lifetime of the repository.
+ * 
+ * In a real app, this would:
+ * - Call network APIs
+ * - Cache data locally
+ * - Handle pagination
+ */
+@Factory
+class ExploreRepository {
+
+    // Cache generated items to avoid regenerating on each call
+    private val cachedItems: List<ExploreItem> by lazy { generateItems() }
+
+    /**
+     * Get all explore items.
+     */
+    fun getItems(): List<ExploreItem> = cachedItems
+
+    /**
+     * Get a single explore item by ID.
+     */
+    fun getItemById(itemId: String): ExploreItem? {
+        return cachedItems.find { it.id == itemId }
+    }
+
+    /**
+     * Get all available categories.
+     */
+    fun getCategories(): List<ExploreCategory> = ExploreCategory.entries
+
+    /**
+     * Generate the full list of sample explore items.
+     */
+    private fun generateItems(): List<ExploreItem> = listOf(
+        // Technology items
+        ExploreItem(
+            id = "tech_1",
+            title = "AI Revolution",
+            subtitle = "How artificial intelligence is transforming industries",
+            category = ExploreCategory.TECHNOLOGY,
+            imageUrl = ExploreItem.imageUrlForId("tech_1"),
+            rating = 4.8f,
+            isFeatured = true
+        ),
+        ExploreItem(
+            id = "tech_2",
+            title = "Quantum Computing",
+            subtitle = "The next frontier in computational power",
+            category = ExploreCategory.TECHNOLOGY,
+            imageUrl = ExploreItem.imageUrlForId("tech_2"),
+            rating = 4.5f
+        ),
+        ExploreItem(
+            id = "tech_3",
+            title = "Blockchain Basics",
+            subtitle = "Understanding decentralized technology",
+            category = ExploreCategory.TECHNOLOGY,
+            imageUrl = ExploreItem.imageUrlForId("tech_3"),
+            rating = 4.2f
+        ),
+        ExploreItem(
+            id = "tech_4",
+            title = "Kotlin Multiplatform",
+            subtitle = "Cross-platform development made easy",
+            category = ExploreCategory.TECHNOLOGY,
+            imageUrl = ExploreItem.imageUrlForId("tech_4"),
+            rating = 4.9f,
+            isFeatured = true
+        ),
+        ExploreItem(
+            id = "tech_5",
+            title = "Cloud Architecture",
+            subtitle = "Building scalable cloud solutions",
+            category = ExploreCategory.TECHNOLOGY,
+            imageUrl = ExploreItem.imageUrlForId("tech_5"),
+            rating = 4.3f
+        ),
+
+        // Design items
+        ExploreItem(
+            id = "design_1",
+            title = "Material Design 3",
+            subtitle = "The evolution of Google's design system",
+            category = ExploreCategory.DESIGN,
+            imageUrl = ExploreItem.imageUrlForId("design_1"),
+            rating = 4.7f,
+            isFeatured = true
+        ),
+        ExploreItem(
+            id = "design_2",
+            title = "Color Theory",
+            subtitle = "Understanding color psychology in UI",
+            category = ExploreCategory.DESIGN,
+            imageUrl = ExploreItem.imageUrlForId("design_2"),
+            rating = 4.4f
+        ),
+        ExploreItem(
+            id = "design_3",
+            title = "Typography Essentials",
+            subtitle = "Choosing the right fonts for your app",
+            category = ExploreCategory.DESIGN,
+            imageUrl = ExploreItem.imageUrlForId("design_3"),
+            rating = 4.1f
+        ),
+        ExploreItem(
+            id = "design_4",
+            title = "Glassmorphism Trends",
+            subtitle = "Modern frosted glass UI patterns",
+            category = ExploreCategory.DESIGN,
+            imageUrl = ExploreItem.imageUrlForId("design_4"),
+            rating = 4.6f
+        ),
+
+        // Travel items
+        ExploreItem(
+            id = "travel_1",
+            title = "Hidden Gems of Japan",
+            subtitle = "Discover off-the-beaten-path destinations",
+            category = ExploreCategory.TRAVEL,
+            imageUrl = ExploreItem.imageUrlForId("travel_1"),
+            rating = 4.9f,
+            isFeatured = true
+        ),
+        ExploreItem(
+            id = "travel_2",
+            title = "European Capitals",
+            subtitle = "A guide to the best cities in Europe",
+            category = ExploreCategory.TRAVEL,
+            imageUrl = ExploreItem.imageUrlForId("travel_2"),
+            rating = 4.5f
+        ),
+        ExploreItem(
+            id = "travel_3",
+            title = "Tropical Paradise",
+            subtitle = "Best beaches for your next vacation",
+            category = ExploreCategory.TRAVEL,
+            imageUrl = ExploreItem.imageUrlForId("travel_3"),
+            rating = 4.7f
+        ),
+        ExploreItem(
+            id = "travel_4",
+            title = "Mountain Adventures",
+            subtitle = "Hiking trails around the world",
+            category = ExploreCategory.TRAVEL,
+            imageUrl = ExploreItem.imageUrlForId("travel_4"),
+            rating = 4.3f
+        ),
+        ExploreItem(
+            id = "travel_5",
+            title = "Safari Experience",
+            subtitle = "Wildlife adventures in Africa",
+            category = ExploreCategory.TRAVEL,
+            imageUrl = ExploreItem.imageUrlForId("travel_5"),
+            rating = 4.8f
+        ),
+
+        // Food items
+        ExploreItem(
+            id = "food_1",
+            title = "Italian Cuisine",
+            subtitle = "Authentic recipes from Italy",
+            category = ExploreCategory.FOOD,
+            imageUrl = ExploreItem.imageUrlForId("food_1"),
+            rating = 4.8f,
+            isFeatured = true
+        ),
+        ExploreItem(
+            id = "food_2",
+            title = "Sushi Mastery",
+            subtitle = "The art of Japanese sushi",
+            category = ExploreCategory.FOOD,
+            imageUrl = ExploreItem.imageUrlForId("food_2"),
+            rating = 4.6f
+        ),
+        ExploreItem(
+            id = "food_3",
+            title = "Street Food Guide",
+            subtitle = "Best street food around the world",
+            category = ExploreCategory.FOOD,
+            imageUrl = ExploreItem.imageUrlForId("food_3"),
+            rating = 4.4f
+        ),
+        ExploreItem(
+            id = "food_4",
+            title = "Vegan Delights",
+            subtitle = "Delicious plant-based recipes",
+            category = ExploreCategory.FOOD,
+            imageUrl = ExploreItem.imageUrlForId("food_4"),
+            rating = 4.2f
+        ),
+        ExploreItem(
+            id = "food_5",
+            title = "Dessert Paradise",
+            subtitle = "Sweet treats from every continent",
+            category = ExploreCategory.FOOD,
+            imageUrl = ExploreItem.imageUrlForId("food_5"),
+            rating = 4.7f
+        ),
+
+        // Nature items
+        ExploreItem(
+            id = "nature_1",
+            title = "Northern Lights",
+            subtitle = "Best places to see the aurora",
+            category = ExploreCategory.NATURE,
+            imageUrl = ExploreItem.imageUrlForId("nature_1"),
+            rating = 4.9f,
+            isFeatured = true
+        ),
+        ExploreItem(
+            id = "nature_2",
+            title = "Rainforest Wonders",
+            subtitle = "Exploring tropical ecosystems",
+            category = ExploreCategory.NATURE,
+            imageUrl = ExploreItem.imageUrlForId("nature_2"),
+            rating = 4.5f
+        ),
+        ExploreItem(
+            id = "nature_3",
+            title = "Ocean Depths",
+            subtitle = "Mysteries of the deep sea",
+            category = ExploreCategory.NATURE,
+            imageUrl = ExploreItem.imageUrlForId("nature_3"),
+            rating = 4.6f
+        ),
+        ExploreItem(
+            id = "nature_4",
+            title = "Desert Landscapes",
+            subtitle = "Beauty in arid environments",
+            category = ExploreCategory.NATURE,
+            imageUrl = ExploreItem.imageUrlForId("nature_4"),
+            rating = 4.3f
+        ),
+
+        // Music items
+        ExploreItem(
+            id = "music_1",
+            title = "Jazz Legends",
+            subtitle = "The greatest jazz musicians of all time",
+            category = ExploreCategory.MUSIC,
+            imageUrl = ExploreItem.imageUrlForId("music_1"),
+            rating = 4.7f,
+            isFeatured = true
+        ),
+        ExploreItem(
+            id = "music_2",
+            title = "Electronic Evolution",
+            subtitle = "The rise of electronic music",
+            category = ExploreCategory.MUSIC,
+            imageUrl = ExploreItem.imageUrlForId("music_2"),
+            rating = 4.4f
+        ),
+        ExploreItem(
+            id = "music_3",
+            title = "Classical Masterpieces",
+            subtitle = "Timeless orchestral compositions",
+            category = ExploreCategory.MUSIC,
+            imageUrl = ExploreItem.imageUrlForId("music_3"),
+            rating = 4.8f
+        ),
+        ExploreItem(
+            id = "music_4",
+            title = "Rock Anthems",
+            subtitle = "Iconic rock songs through the decades",
+            category = ExploreCategory.MUSIC,
+            imageUrl = ExploreItem.imageUrlForId("music_4"),
+            rating = 4.5f
+        ),
+        ExploreItem(
+            id = "music_5",
+            title = "World Music",
+            subtitle = "Traditional sounds from every culture",
+            category = ExploreCategory.MUSIC,
+            imageUrl = ExploreItem.imageUrlForId("music_5"),
+            rating = 4.2f
+        ),
+
+        // Sports items
+        ExploreItem(
+            id = "sports_1",
+            title = "Football Legends",
+            subtitle = "Greatest players in football history",
+            category = ExploreCategory.SPORTS,
+            imageUrl = ExploreItem.imageUrlForId("sports_1"),
+            rating = 4.8f,
+            isFeatured = true
+        ),
+        ExploreItem(
+            id = "sports_2",
+            title = "Olympic Heroes",
+            subtitle = "Inspiring stories from the Olympics",
+            category = ExploreCategory.SPORTS,
+            imageUrl = ExploreItem.imageUrlForId("sports_2"),
+            rating = 4.6f
+        ),
+        ExploreItem(
+            id = "sports_3",
+            title = "Extreme Sports",
+            subtitle = "Adrenaline-pumping adventures",
+            category = ExploreCategory.SPORTS,
+            imageUrl = ExploreItem.imageUrlForId("sports_3"),
+            rating = 4.4f
+        ),
+        ExploreItem(
+            id = "sports_4",
+            title = "Tennis Champions",
+            subtitle = "Grand Slam winners and their journeys",
+            category = ExploreCategory.SPORTS,
+            imageUrl = ExploreItem.imageUrlForId("sports_4"),
+            rating = 4.3f
+        ),
+        ExploreItem(
+            id = "sports_5",
+            title = "Basketball Dynasties",
+            subtitle = "The most dominant teams in NBA history",
+            category = ExploreCategory.SPORTS,
+            imageUrl = ExploreItem.imageUrlForId("sports_5"),
+            rating = 4.7f
+        )
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/masterdetail/DetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/masterdetail/DetailScreen.kt
@@ -77,7 +77,8 @@ fun DetailScreen(
     val relatedItems = (1..RELATED_ITEMS_COUNT).map { "Related item $it" }
     
     // Get transition scope - animations are tied to this
-    val transitionScope = com.jermey.quo.vadis.core.compose.transition.LocalTransitionScope.current
+    // Use rememberTransitionScope() for proper animation during navigation
+    val transitionScope = com.jermey.quo.vadis.core.compose.transition.rememberTransitionScope()
 
     Box(modifier = Modifier.fillMaxSize()) {
         // Animated background - fades with navigation

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/profile/ProfileContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/profile/ProfileContainer.kt
@@ -3,6 +3,9 @@ package com.jermey.navplayground.demo.ui.screens.profile
 import com.jermey.navplayground.demo.destinations.MainTabs
 import com.jermey.quo.vadis.flowmvi.NavigationContainer
 import com.jermey.quo.vadis.flowmvi.NavigationContainerScope
+import org.koin.core.annotation.Qualifier
+import org.koin.core.annotation.Scope
+import org.koin.core.annotation.Scoped
 import pro.respawn.flowmvi.api.PipelineContext
 import pro.respawn.flowmvi.api.Store
 import pro.respawn.flowmvi.dsl.store
@@ -27,6 +30,9 @@ private typealias Ctx = PipelineContext<ProfileState, ProfileIntent, ProfileActi
  *
  * Uses [NavigationContainer] for proper lifecycle integration with the navigation system.
  */
+@Scoped
+@Scope(NavigationContainerScope::class)
+@Qualifier(ProfileContainer::class)
 class ProfileContainer(
     scope: NavigationContainerScope,
     private val repository: ProfileRepository,

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/profile/ProfileRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/profile/ProfileRepository.kt
@@ -1,6 +1,7 @@
 package com.jermey.navplayground.demo.ui.screens.profile
 
 import kotlinx.coroutines.delay
+import org.koin.core.annotation.Factory
 
 
 /**
@@ -12,6 +13,7 @@ import kotlinx.coroutines.delay
  * - Handle authentication
  * - Provide reactive data streams
  */
+@Factory
 class ProfileRepository {
 
     companion object {

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/statedriven/StateDrivenContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/statedriven/StateDrivenContainer.kt
@@ -11,10 +11,14 @@ import com.jermey.quo.vadis.core.navigation.node.NavNode
 import com.jermey.quo.vadis.core.navigation.node.ScreenNode
 import com.jermey.quo.vadis.core.navigation.node.StackNode
 import com.jermey.quo.vadis.core.navigation.node.TabNode
+import com.jermey.quo.vadis.flowmvi.NavigationContainerScope
 import com.jermey.quo.vadis.flowmvi.SharedContainerScope
 import com.jermey.quo.vadis.flowmvi.SharedNavigationContainer
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import org.koin.core.annotation.Qualifier
+import org.koin.core.annotation.Scope
+import org.koin.core.annotation.Scoped
 import pro.respawn.flowmvi.api.PipelineContext
 import pro.respawn.flowmvi.api.Store
 import pro.respawn.flowmvi.dsl.store
@@ -44,6 +48,9 @@ private typealias Ctx = PipelineContext<StateDrivenState, StateDrivenIntent, Sta
  * @param scope The shared container scope providing access to navigator.
  * @param debuggable Whether to enable debug logging for the store.
  */
+@Scoped
+@Scope(SharedContainerScope::class)
+@Qualifier(StateDrivenContainer::class)
 class StateDrivenContainer(
     scope: SharedContainerScope,
     private val debuggable: Boolean = false

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/statedriven/StateDrivenDemoScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/statedriven/StateDrivenDemoScreen.kt
@@ -42,6 +42,7 @@ import com.jermey.quo.vadis.annotations.TabsContainer
 import com.jermey.quo.vadis.core.compose.scope.TabsContainerScope
 import com.jermey.quo.vadis.flowmvi.rememberSharedContainer
 import kotlinx.coroutines.launch
+import org.koin.core.qualifier.qualifier
 import pro.respawn.flowmvi.compose.dsl.subscribe
 
 /**
@@ -71,7 +72,9 @@ fun StateDrivenDemoContainer(
     val coroutineScope = rememberCoroutineScope()
 
     // Get the shared store for state-driven navigation manipulation
-    val sharedStore = rememberSharedContainer<StateDrivenContainer, StateDrivenState, StateDrivenIntent, StateDrivenAction>()
+    val sharedStore = rememberSharedContainer<StateDrivenContainer, StateDrivenState, StateDrivenIntent, StateDrivenAction>(
+        qualifier = qualifier<StateDrivenContainer>()
+    )
 
     val state by sharedStore.subscribe { action ->
         coroutineScope.launch {

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/tabs/DemoTabsContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/tabs/DemoTabsContainer.kt
@@ -2,8 +2,12 @@ package com.jermey.navplayground.demo.ui.screens.tabs
 
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
+import com.jermey.quo.vadis.flowmvi.NavigationContainerScope
 import com.jermey.quo.vadis.flowmvi.SharedContainerScope
 import com.jermey.quo.vadis.flowmvi.SharedNavigationContainer
+import org.koin.core.annotation.Qualifier
+import org.koin.core.annotation.Scope
+import org.koin.core.annotation.Scoped
 import pro.respawn.flowmvi.api.MVIAction
 import pro.respawn.flowmvi.api.MVIIntent
 import pro.respawn.flowmvi.api.MVIState
@@ -80,6 +84,9 @@ sealed interface DemoTabsAction : MVIAction
  *
  * @param scope The shared container scope providing access to navigator and lifecycle
  */
+@Scoped
+@Scope(SharedContainerScope::class)
+@Qualifier(DemoTabsContainer::class)
 class DemoTabsContainer(
     scope: SharedContainerScope,
 ) : SharedNavigationContainer<DemoTabsState, DemoTabsIntent, DemoTabsAction>(scope) {

--- a/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/tabs/TabsDemoWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/jermey/navplayground/demo/ui/screens/tabs/TabsDemoWrapper.kt
@@ -27,6 +27,7 @@ import com.jermey.navplayground.demo.destinations.DemoTabs
 import com.jermey.quo.vadis.annotations.TabsContainer
 import com.jermey.quo.vadis.core.compose.scope.TabsContainerScope
 import com.jermey.quo.vadis.flowmvi.rememberSharedContainer
+import org.koin.core.qualifier.qualifier
 import pro.respawn.flowmvi.compose.dsl.subscribe
 
 /**
@@ -52,7 +53,9 @@ fun DemoTabsWrapper(
     content: @Composable () -> Unit
 ) {
     // Get the shared store for cross-tab state
-    val sharedStore = rememberSharedContainer<DemoTabsContainer, DemoTabsState, DemoTabsIntent, DemoTabsAction>()
+    val sharedStore = rememberSharedContainer<DemoTabsContainer, DemoTabsState, DemoTabsIntent, DemoTabsAction>(
+        qualifier = qualifier<DemoTabsContainer>()
+    )
     val state by sharedStore.subscribe()
 
     CompositionLocalProvider(LocalDemoTabsStore provides sharedStore) {

--- a/composeApp/src/desktopMain/kotlin/com/jermey/navplayground/demo/CoilSetup.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/jermey/navplayground/demo/CoilSetup.desktop.kt
@@ -1,0 +1,14 @@
+package com.jermey.navplayground.demo
+
+import coil3.PlatformContext
+import java.io.File
+
+/**
+ * Get platform-specific cache directory for Desktop (JVM).
+ */
+internal actual fun getCacheDirectory(context: PlatformContext): String {
+    val userHome = System.getProperty("user.home")
+    val cacheDir = File(userHome, ".cache/navplayground/coil_cache")
+    cacheDir.mkdirs()
+    return cacheDir.absolutePath
+}

--- a/composeApp/src/iosMain/kotlin/com/jermey/navplayground/demo/CoilSetup.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/jermey/navplayground/demo/CoilSetup.ios.kt
@@ -1,0 +1,18 @@
+package com.jermey.navplayground.demo
+
+import coil3.PlatformContext
+import platform.Foundation.NSCachesDirectory
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSUserDomainMask
+
+/**
+ * Get platform-specific cache directory for iOS.
+ */
+internal actual fun getCacheDirectory(context: PlatformContext): String {
+    val paths = NSSearchPathForDirectoriesInDomains(
+        NSCachesDirectory,
+        NSUserDomainMask,
+        true
+    )
+    return (paths.firstOrNull() as? String ?: "") + "/coil_cache"
+}

--- a/composeApp/src/jsMain/kotlin/com/jermey/navplayground/demo/CoilSetup.js.kt
+++ b/composeApp/src/jsMain/kotlin/com/jermey/navplayground/demo/CoilSetup.js.kt
@@ -1,0 +1,14 @@
+package com.jermey.navplayground.demo
+
+import coil3.PlatformContext
+
+/**
+ * Get platform-specific cache directory for JS.
+ * Note: JS/WASM doesn't support file-based disk caching, so return empty string.
+ * Coil will use memory-only caching on these platforms.
+ */
+internal actual fun getCacheDirectory(context: PlatformContext): String {
+    // JS doesn't have filesystem access for disk caching
+    // Coil falls back to memory-only caching when disk cache path is unavailable
+    return ""
+}

--- a/composeApp/src/wasmJsMain/kotlin/com/jermey/navplayground/demo/CoilSetup.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/jermey/navplayground/demo/CoilSetup.wasmJs.kt
@@ -1,0 +1,14 @@
+package com.jermey.navplayground.demo
+
+import coil3.PlatformContext
+
+/**
+ * Get platform-specific cache directory for WASM JS.
+ * Note: WASM/JS doesn't support file-based disk caching, so return empty string.
+ * Coil will use memory-only caching on these platforms.
+ */
+internal actual fun getCacheDirectory(context: PlatformContext): String {
+    // WASM JS doesn't have filesystem access for disk caching
+    // Coil falls back to memory-only caching when disk cache path is unavailable
+    return ""
+}

--- a/feature1/build.gradle.kts
+++ b/feature1/build.gradle.kts
@@ -156,10 +156,6 @@ kotlin {
         }
     }
 
-    ksp {
-        arg("KOIN_DEFAULT_MODULE", "true")
-    }
-
     // KSP Common sourceSet
     sourceSets.named("commonMain").configure {
         kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")

--- a/feature1/src/commonMain/kotlin/com/jermey/feature1/resultdemo/Di.kt
+++ b/feature1/src/commonMain/kotlin/com/jermey/feature1/resultdemo/Di.kt
@@ -1,0 +1,8 @@
+package com.jermey.feature1.resultdemo
+
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+
+@Module
+@ComponentScan
+class Feature1Module

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,10 @@ flowmvi = "3.2.1"
 koin = "4.2.0-beta2"
 koin-annotations = "2.3.2-Beta1"
 androidx-security = "1.1.0"
-navigationevent = "1.0.0-rc02"
+navigationevent = "1.0.0"
+haze = "1.7.1"
+coil = "3.3.0"
+ktor = "3.3.3"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -70,6 +73,20 @@ androidx-security-crypto = { module = "androidx.security:security-crypto", versi
 
 # NavigationEvent
 navigationevent-compose = { module = "org.jetbrains.androidx.navigationevent:navigationevent-compose", version.ref = "navigationevent" }
+
+# Haze (Glassmorphism blur effects)
+haze = { module = "dev.chrisbanes.haze:haze", version.ref = "haze" }
+haze-materials = { module = "dev.chrisbanes.haze:haze-materials", version.ref = "haze" }
+
+# Coil (Image loading)
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
+
+# Ktor client (for Coil networking on all platforms)
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/quo-vadis-core-flow-mvi/src/commonMain/kotlin/com/jermey/quo/vadis/flowmvi/ContainerComposables.kt
+++ b/quo-vadis-core-flow-mvi/src/commonMain/kotlin/com/jermey/quo/vadis/flowmvi/ContainerComposables.kt
@@ -213,10 +213,11 @@ inline fun <reified Container, State, Intent, Action> rememberSharedContainer(
  */
 @FlowMVIDSL
 inline fun <reified Container : NavigationContainer<*, *, *>> Module.navigationContainer(
+    qualifier: Qualifier = qualifier<Container>(),
     crossinline factory: (NavigationContainerScope) -> Container,
 ) {
     scope<NavigationContainerScope> {
-        scoped<Container> { factory(get()) }
+        scoped<Container>(qualifier = qualifier) { factory(get()) }
     }
 }
 

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/internal/render/AnimatedNavContent.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/internal/render/AnimatedNavContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -39,6 +40,16 @@ import com.jermey.quo.vadis.core.navigation.node.NavNode
  * The component maintains internal state for predictive back:
  * - **lastCommittedState**: The state currently shown on screen
  * - **stateBeforeLast**: The previous state for gesture target resolution
+ *
+ * ## Shared Element Scope Provision
+ *
+ * The [AnimatedVisibilityScope] is ALWAYS provided to all children during navigation
+ * transitions. This ensures that shared element transitions work correctly because:
+ * - Both entering and exiting content use the SAME AnimatedVisibilityScope object
+ * - Exit content doesn't recompose to read updated composition locals, so passing
+ *   the scope directly via parameter is essential
+ * - Nested structures (screens inside tabs/panes) can access the correct scope
+ *   even during exit animations
  *
  * ## Usage
  *

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/internal/render/PaneRenderer.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/internal/render/PaneRenderer.kt
@@ -2,6 +2,7 @@
 
 package com.jermey.quo.vadis.core.compose.internal.render
 
+import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -93,6 +94,8 @@ internal fun PaneRenderer(
     node: PaneNode,
     previousNode: PaneNode?,
     scope: NavRenderScope,
+    @Suppress("UNUSED_PARAMETER")
+    animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
     // Detect window size class for adaptive layout decision
     val windowSizeClass = calculateWindowSizeClass()
@@ -285,13 +288,11 @@ private fun SinglePaneRenderer(
             scope = scope
         ) { paneNavNode ->
             // Render each pane content via NavNodeRenderer
-            StaticAnimatedVisibilityScope {
-                NavNodeRenderer(
-                    node = paneNavNode,
-                    previousNode = null,
-                    scope = scope
-                )
-            }
+            NavNodeRenderer(
+                node = paneNavNode,
+                previousNode = null,
+                scope = scope,
+            )
         }
         // Note: Do NOT update lastCommittedContent during predictive back
         // We want to keep showing the "old" state (SECONDARY) as current

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/internal/render/PredictiveBackContent.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/internal/render/PredictiveBackContent.kt
@@ -65,8 +65,8 @@ import com.jermey.quo.vadis.core.navigation.node.NavNode
  *                 Values outside this range are clamped internally by transform calculations.
  * @param scope The [NavRenderScope] providing access to cache, state holder, and other
  *              rendering dependencies
- * @param content The composable content to render for each node, receiving an
- *                [AnimatedVisibilityScope] for compatibility with animated visibility modifiers
+ * @param content The composable content to render for each node, receiving the node
+ *                and optionally an [AnimatedVisibilityScope] for compatibility with animated visibility modifiers
  *
  * @see NavRenderScope
  * @see StaticAnimatedVisibilityScope

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/internal/render/StackRenderer.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/internal/render/StackRenderer.kt
@@ -2,6 +2,7 @@
 
 package com.jermey.quo.vadis.core.compose.internal.render
 
+import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.runtime.Composable
 import com.jermey.quo.vadis.core.InternalQuoVadisApi
 import com.jermey.quo.vadis.core.compose.scope.NavRenderScope
@@ -37,6 +38,13 @@ import com.jermey.quo.vadis.core.navigation.node.StackNode
  * If the stack is empty (no children), this renderer returns early without
  * producing any UI. Parent nodes should handle cascading empty stack removal.
  *
+ * ## Shared Element Transitions
+ *
+ * The [animatedVisibilityScope] parameter is passed through from the parent.
+ * When AnimatedNavContent renders screen nodes, it provides its own scope
+ * directly to NavNodeRenderer, ensuring both entering and exiting screens
+ * use the same scope for shared element transitions.
+ *
  * ## Example
  *
  * ```kotlin
@@ -54,6 +62,8 @@ import com.jermey.quo.vadis.core.navigation.node.StackNode
  * @param previousNode The previous stack state for animation direction detection.
  *   Used to determine if this is forward or back navigation.
  * @param scope The render scope with dependencies (AnimationCoordinator, etc.)
+ * @param animatedVisibilityScope Optional AnimatedVisibilityScope from parent.
+ *   Not used directly here but part of the signature for consistency.
  *
  * @see StackNode
  * @see AnimatedNavContent
@@ -64,6 +74,8 @@ internal fun StackRenderer(
     node: StackNode,
     previousNode: StackNode?,
     scope: NavRenderScope,
+    @Suppress("UNUSED_PARAMETER")
+    animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
     // Early return for empty stack - no content to render
     val activeChild = node.activeChild ?: return

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/internal/render/StaticAnimatedVisibilityScope.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/internal/render/StaticAnimatedVisibilityScope.kt
@@ -29,13 +29,13 @@ import com.jermey.quo.vadis.core.compose.transition.TransitionScope
  *
  * ## Usage
  * ```kotlin
- * StaticAnimatedVisibilityScope {
+ * StaticAnimatedVisibilityScope { scope ->
  *     // Content that needs AnimatedVisibilityScope
- *     content(previous)
+ *     content(node, scope)
  * }
  * ```
  *
- * @param content The composable content requiring an [AnimatedVisibilityScope]
+ * @param content The composable content receiving the [AnimatedVisibilityScope]
  */
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -57,7 +57,7 @@ internal fun StaticAnimatedVisibilityScope(
         LocalAnimatedVisibilityScope provides scope,
         LocalTransitionScope provides transitionScope
     ) {
-        scope.content()
+        content(scope)
     }
 }
 

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/internal/render/TabRenderer.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/internal/render/TabRenderer.kt
@@ -2,6 +2,7 @@
 
 package com.jermey.quo.vadis.core.compose.internal.render
 
+import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -74,6 +75,8 @@ import com.jermey.quo.vadis.core.navigation.node.TabNode
  * @param node The tab node to render
  * @param previousNode The previous tab state for animation direction detection
  * @param scope The render scope with dependencies and context
+ * @param animatedVisibilityScope Optional AnimatedVisibilityScope from parent.
+ *   Not used directly here but part of the signature for consistency.
  *
  * @see TabNode
  * @see com.jermey.quo.vadis.core.compose.scope.TabsContainerScope
@@ -88,6 +91,8 @@ internal fun TabRenderer(
     node: TabNode,
     previousNode: TabNode?,
     scope: NavRenderScope,
+    @Suppress("UNUSED_PARAMETER")
+    animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
     // Get active stack for the current and previous state
     val activeStack = node.activeStack

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/transition/TransitionScope.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/compose/transition/TransitionScope.kt
@@ -3,6 +3,7 @@ package com.jermey.quo.vadis.core.compose.transition
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
 
 /**
@@ -65,5 +66,24 @@ fun TransitionScope(
  * This scope combines SharedTransitionScope and AnimatedVisibilityScope for easier usage.
  *
  * Returns null if shared elements are not enabled or if not within a transition context.
+ *
+ * **Important**: This composition local may become stale during animations. For shared elements
+ * that need the current animation state, use [rememberTransitionScope] instead.
  */
 val LocalTransitionScope = compositionLocalOf<TransitionScope?> { null }
+
+/**
+ * Creates a [TransitionScope] by combining the current shared transition and animated visibility
+ * scopes from the composition hierarchy.
+ *
+ * Use this function to access the [TransitionScope] within screen content for shared element
+ * transitions. It retrieves the scope from [LocalTransitionScope] which is provided by the
+ * navigation framework during animated transitions.
+ *
+ * @return A [TransitionScope] if available, null otherwise.
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun rememberTransitionScope(): TransitionScope? {
+    return LocalTransitionScope.current
+}

--- a/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/registry/RouteRegistry.kt
+++ b/quo-vadis-core/src/commonMain/kotlin/com/jermey/quo/vadis/core/registry/RouteRegistry.kt
@@ -15,7 +15,6 @@ object RouteRegistry {
      * Register a route for a destination class.
      */
     fun register(destinationClass: KClass<*>, route: String) {
-        println("DEBUG: RouteRegistry.register - class=$destinationClass, route=$route")
         routes[destinationClass] = route
     }
     
@@ -23,10 +22,7 @@ object RouteRegistry {
      * Get the registered route for a destination class.
      */
     fun getRoute(destinationClass: KClass<*>): String? {
-        val route = routes[destinationClass]
-        val allRoutes = routes.keys.map { it.simpleName }
-        println("DEBUG: RouteRegistry.getRoute - class=$destinationClass, route=$route, allRoutes=$allRoutes")
-        return route
+        return routes[destinationClass]
     }
 
 }


### PR DESCRIPTION
This pull request introduces several major improvements and refactorings to the app's architecture, dependency injection, and feature modules. The most significant changes include a migration to Koin's annotation-based DI for feature modules, a new tab navigation structure for the Explore feature, and the addition of robust image loading support using Coil and Ktor. There are also updates to permissions, build dependencies, and static analysis configuration.

**Dependency Injection and Feature Module Refactor:**
* Migrated feature modules (`Profile`, `StateDrivenDemo`, `TabsDemo`, `Explore`) to use Koin annotation-based modules (`@Module`, `@ComponentScan`) for improved modularity and automatic DI registration. Old manual DI setup code was removed from `DI.kt`, and new modules are registered in `App.kt`. [[1]](diffhunk://#diff-8567377321ffa1c23b370504f60e07163c400da82269904db7ee557037e2c957L49-R61) [[2]](diffhunk://#diff-957d557e8ab089a9e87f0cb2a0069c2924a89cf5bb4e8049939ff1f390bc4958L9-R31)
* Updated Koin module imports in `App.kt` to reference generated annotation-based modules, removing legacy manual modules.

**Navigation and Destinations:**
* Refactored the `ExploreTab` in `MainTabs.kt` to use a dedicated navigation stack with explicit feed, detail, and category destinations, enabling master-detail navigation and deep linking for the Explore feature.
* Added argument annotations to `ExploreTab.Detail` and `ExploreTab.CategoryView` for type-safe navigation parameters.

**Image Loading and Caching:**
* Added a cross-platform Coil image loader setup (`CoilSetup.kt` and platform-specific `CoilSetup.android.kt`) with Ktor networking, memory/disk caching, and crossfade transitions. The loader is configured at app startup for consistent image loading across platforms. [[1]](diffhunk://#diff-dbd3d37fc60b6690b830846d67d81921a5f9a08609823d88859da6b8a1120eeeR1-R74) [[2]](diffhunk://#diff-184ceae8085ee45aa8c7269fa4b58407fff67d4b7130ed7b4ccac39c48c30102R1-R10) [[3]](diffhunk://#diff-b7b5cba5f8bf9644ec0635c1eb8fc6a16f8d2b20af921ebd7e9ed835cac8fc06R40-R42)
* Updated Gradle dependencies to include Coil, Ktor, and Haze libraries for image loading and glassmorphism effects on all supported platforms. [[1]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aR74) [[2]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aR100-R129)

**Permissions and Manifest Updates:**
* Added the `INTERNET` permission to `AndroidManifest.xml` to enable network requests for image loading and other features.
* Minor reordering of attributes in the `MainActivity` manifest entry for clarity.

**Static Analysis and Code Quality:**
* Updated the Detekt baseline to reflect new long methods, magic numbers, and other static analysis findings in newly added Explore and image preview screens. [[1]](diffhunk://#diff-927145e3f6a6b1c76c03af8241804babc90ef2a8a5b77adc0e7633a508ed30b7R14-R45) [[2]](diffhunk://#diff-927145e3f6a6b1c76c03af8241804babc90ef2a8a5b77adc0e7633a508ed30b7L43-R68)

These changes collectively improve the app's scalability, maintainability, and feature support, especially for navigation and media handling.

---

**References:**  
DI and Feature Modules: [[1]](diffhunk://#diff-8567377321ffa1c23b370504f60e07163c400da82269904db7ee557037e2c957L49-R61) [[2]](diffhunk://#diff-957d557e8ab089a9e87f0cb2a0069c2924a89cf5bb4e8049939ff1f390bc4958L9-R31)  
Navigation and Destinations:  
Image Loading and Caching: [[1]](diffhunk://#diff-dbd3d37fc60b6690b830846d67d81921a5f9a08609823d88859da6b8a1120eeeR1-R74) [[2]](diffhunk://#diff-184ceae8085ee45aa8c7269fa4b58407fff67d4b7130ed7b4ccac39c48c30102R1-R10) [[3]](diffhunk://#diff-b7b5cba5f8bf9644ec0635c1eb8fc6a16f8d2b20af921ebd7e9ed835cac8fc06R40-R42) [[4]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aR74) [[5]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aR100-R129)  
Permissions: [[1]](diffhunk://#diff-1cf4c0d0f45b91d67ef0351cac8996b079c8c0355fd9bf2409507c98278a6e8aR4-R5) [[2]](diffhunk://#diff-1cf4c0d0f45b91d67ef0351cac8996b079c8c0355fd9bf2409507c98278a6e8aL12-R15)  
Static Analysis: [[1]](diffhunk://#diff-927145e3f6a6b1c76c03af8241804babc90ef2a8a5b77adc0e7633a508ed30b7R14-R45) [[2]](diffhunk://#diff-927145e3f6a6b1c76c03af8241804babc90ef2a8a5b77adc0e7633a508ed30b7L43-R68)